### PR TITLE
Fix critical agent loop, subagent, CLI and web coverage gaps

### DIFF
--- a/agent/anthropic_llm.py
+++ b/agent/anthropic_llm.py
@@ -156,6 +156,7 @@ class AnthropicLLM(BaseLLM):
             "end_turn": "end_turn",
             "max_tokens": "max_tokens",
             "stop_sequence": "stop",
+            "tool_use": "tool_calls",
         }
         api_stop_reason = stop_reason_map.get(data.get("stop_reason", ""), "end_turn")
 

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -91,10 +91,36 @@ class AgentLoop:
             messages.append(Message(role="assistant", content=response.content or "", tool_calls=list(response.tool_calls), reasoning_content=response.reasoning_content))
 
             for delta in response.tool_calls:
+                try:
+                    arguments = self._parse_arguments(delta.arguments)
+                except ValueError as e:
+                    tool_call = ToolCall(id=delta.id, name=delta.name, arguments={})
+                    logger.error(f"[AgentLoop] invalid arguments for tool {delta.name}: {e}")
+                    await self.hooks.on_error(e)
+                    result = f"[Error: {e}]"
+
+                    if on_event:
+                        await on_event("tool_call", {
+                            "name": tool_call.name,
+                            "arguments": tool_call.arguments,
+                        })
+                        await on_event("tool_result", {
+                            "name": tool_call.name,
+                            "result": result,
+                        })
+
+                    messages.append(tool_result_message(tool_call.id, result))
+                    tool_calls_made.append(ToolCallMade(
+                        name=tool_call.name,
+                        arguments=tool_call.arguments,
+                        result=result,
+                    ))
+                    continue
+
                 tool_call = ToolCall(
                     id=delta.id,
                     name=delta.name,
-                    arguments=self._parse_arguments(delta.arguments),
+                    arguments=arguments,
                 )
 
                 await self.hooks.before_tool_execute(tool_call)
@@ -132,28 +158,32 @@ class AgentLoop:
                 })
 
         logger.warning(f"[AgentLoop] 达到最大迭代次数 {self.max_iterations}")
-        await self.hooks.on_completion(RunResult(
-            content=messages[-1].content if messages else "",
-            stop_reason=StopReason.MAX_ITERATIONS,
-            tool_calls_made=tool_calls_made,
-        ))
-        if on_event:
-            await on_event("done", {
-                "content": messages[-1].content if messages else "",
-                "stop_reason": "max_iterations",
-            })
-        # max_iterations 路径：保留最后一条有内容的非 tool 消息作为 assistant 回复
-        last_content = messages[-1].content if messages else ""
-        messages.append(Message(role="assistant", content=last_content))
-        return RunResult(
-            content=messages[-1].content if messages else "",
+        final_content = self._last_assistant_content(messages)
+        result = RunResult(
+            content=final_content,
             stop_reason=StopReason.MAX_ITERATIONS,
             tool_calls_made=tool_calls_made,
         )
+        await self.hooks.on_completion(result)
+        if on_event:
+            await on_event("done", {
+                "content": final_content,
+                "stop_reason": "max_iterations",
+            })
+        return result
 
     def _parse_arguments(self, arguments: str) -> dict:
         import json
         try:
-            return json.loads(arguments)
-        except json.JSONDecodeError:
-            return {}
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"invalid JSON tool arguments: {e.msg}") from e
+        if not isinstance(parsed, dict):
+            raise ValueError("tool arguments must be a JSON object")
+        return parsed
+
+    def _last_assistant_content(self, messages: list[Message]) -> str:
+        for message in reversed(messages):
+            if message.role == "assistant" and message.content:
+                return message.content
+        return ""

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -45,8 +45,9 @@ class MemoryManager:
     def compact(self, messages: Optional[list["Message"]] = None) -> None:
         msgs = messages if messages is not None else self.messages
         system = [m for m in msgs if m.role == "system"]
-        recent = msgs[-self.recent_window:]
-        middle = msgs[:-self.recent_window]
+        non_system = [m for m in msgs if m.role != "system"]
+        recent = self._recent_with_tool_chains(non_system)
+        middle = non_system[: max(0, len(non_system) - len(recent))]
 
         if not middle:
             msgs[:] = system + recent
@@ -60,6 +61,40 @@ class MemoryManager:
 
         msgs[:] = system + recent
         logger.info(f"[Memory] Compacted to {len(msgs)} messages")
+
+    def _recent_with_tool_chains(self, messages: list["Message"]) -> list["Message"]:
+        if self.recent_window <= 0:
+            return []
+
+        start = max(0, len(messages) - self.recent_window)
+        while start > 0:
+            expanded = False
+            for index in range(start, len(messages)):
+                message = messages[index]
+                if message.role != "tool" or not message.tool_call_id:
+                    continue
+                assistant_index = self._find_tool_call_assistant(messages, message.tool_call_id, before=index)
+                if assistant_index is not None and assistant_index < start:
+                    start = assistant_index
+                    expanded = True
+                    break
+            if not expanded:
+                break
+        return messages[start:]
+
+    def _find_tool_call_assistant(
+        self,
+        messages: list["Message"],
+        tool_call_id: str,
+        before: int,
+    ) -> Optional[int]:
+        for index in range(before - 1, -1, -1):
+            message = messages[index]
+            if message.role != "assistant":
+                continue
+            if any(getattr(tool_call, "id", None) == tool_call_id for tool_call in message.tool_calls):
+                return index
+        return None
 
     def get_messages(self) -> list["Message"]:
         return self.messages

--- a/agent/subagent/manager.py
+++ b/agent/subagent/manager.py
@@ -52,9 +52,17 @@ class SubAgentManager:
                 response = await llm.chat(messages, model=model)
                 result = response.content or "[无内容返回]"
 
-            channel.put_result(result, tool_call_id=f"subagent_{subagent_id}", task=task)
+            channel.put_result(
+                task=task,
+                tool_call_id=f"subagent_{subagent_id}",
+                result=result,
+            )
         except Exception as e:
-            channel.put_result(f"[Error] {e}", tool_call_id=f"subagent_{subagent_id}", task=task)
+            channel.put_result(
+                task=task,
+                tool_call_id=f"subagent_{subagent_id}",
+                result=f"[Error] {e}",
+            )
         finally:
             self._subagents.pop(subagent_id, None)
 

--- a/agent/tools/builtin/grep.py
+++ b/agent/tools/builtin/grep.py
@@ -21,6 +21,7 @@ class GrepTool(Tool):
 
     async def execute(self, pattern: str, path: str, recursive: bool = False, **kwargs) -> str:
         try:
+            regex = re.compile(pattern)
             p = Path(path)
             if not p.exists():
                 return f"Error: 路径不存在: {path}"
@@ -30,7 +31,7 @@ class GrepTool(Tool):
             for f in files:
                 try:
                     for i, line in enumerate(f.read_text(errors="replace").splitlines(), 1):
-                        if re.search(pattern, line):
+                        if regex.search(line):
                             results.append(f"{f}:{i}: {line.rstrip()}")
                 except Exception:
                     pass

--- a/agent/tools/sandbox.py
+++ b/agent/tools/sandbox.py
@@ -31,7 +31,10 @@ class SandboxExecutor:
                 stdout, _ = await asyncio.wait_for(
                     proc.communicate(), timeout=timeout
                 )
-                return stdout.decode(errors="replace").strip()
+                output = stdout.decode(errors="replace").strip()
+                if proc.returncode:
+                    return f"[Exit {proc.returncode}] {output}".strip()
+                return output
             except asyncio.TimeoutError:
                 proc.kill()
                 await proc.wait()
@@ -49,7 +52,10 @@ class SandboxExecutor:
                 text=True,
                 timeout=timeout or self.timeout,
             )
-            return result.stdout.strip()
+            output = (result.stdout + result.stderr).strip()
+            if result.returncode:
+                return f"[Exit {result.returncode}] {output}".strip()
+            return output
         except subprocess.TimeoutExpired:
             return f"[Timeout after {timeout}s]"
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+pythonpath = ["."]
 testpaths = ["tests"]
 markers = [
     "real_api: tests that require a real LLM API endpoint",

--- a/tests/agent/hooks/test_logging_tracing.py
+++ b/tests/agent/hooks/test_logging_tracing.py
@@ -3,22 +3,18 @@ import pytest
 from agent.hooks.builtin.logging import LoggingHook
 from agent.hooks.builtin.tracing import TracingHook
 from agent.message import Message
-from agent.llm import LLMResponse
 from agent.tools.base import ToolCall
 
-def test_logging_hook_no_crash():
-    hook = LoggingHook(verbose=False)
-    # Should not raise
-    import asyncio
-    asyncio.get_event_loop().run_until_complete(
-        hook.before_iteration(0, [Message(role="user", content="test")])
-    )
 
-def test_tracing_hook_record():
+@pytest.mark.asyncio
+async def test_logging_hook_no_crash():
+    hook = LoggingHook(verbose=False)
+    await hook.before_iteration(0, [Message(role="user", content="test")])
+
+
+@pytest.mark.asyncio
+async def test_tracing_hook_record():
     hook = TracingHook()
-    import asyncio
-    asyncio.get_event_loop().run_until_complete(
-        hook.before_tool_execute(ToolCall(id="c1", name="Read", arguments={"path": "a.txt"}))
-    )
+    await hook.before_tool_execute(ToolCall(id="c1", name="Read", arguments={"path": "a.txt"}))
     assert len(hook.calls) == 1
     assert hook.calls[0].tool_name == "Read"

--- a/tests/agent/subagent/test_subagent_manager.py
+++ b/tests/agent/subagent/test_subagent_manager.py
@@ -1,8 +1,23 @@
-# tests/Agent/subagent/test_manager.py
 import pytest
 import asyncio
-from unittest.mock import AsyncMock
 from agent.subagent.manager import SubAgentManager
+from agent.llm import LLMResponse
+
+
+class StaticLLM:
+    async def chat(self, messages, tools=None, model="gpt-4"):
+        return LLMResponse(content="subagent done", stop_reason="end_turn")
+
+
+class FailingLLM:
+    async def chat(self, messages, tools=None, model="gpt-4"):
+        raise RuntimeError("llm failed")
+
+
+class SlowLLM:
+    async def chat(self, messages, tools=None, model="gpt-4"):
+        await asyncio.sleep(10)
+        return LLMResponse(content="late", stop_reason="end_turn")
 
 @pytest.mark.asyncio
 async def test_delegate_returns_subagent_id():
@@ -19,13 +34,52 @@ async def test_delegate_returns_subagent_id():
 @pytest.mark.asyncio
 async def test_list_subagents():
     manager = SubAgentManager()
-    task_id = await manager.delegate(task="task1", tools=[], model="gpt-4o-mini", llm=None)
+    task_id = await manager.delegate(task="task1", tools=[], model="gpt-4o-mini", llm=SlowLLM())
     assert task_id in manager.list_subagents()
+    assert await manager.cancel(task_id) is True
+
+
+@pytest.mark.asyncio
+async def test_subagent_success_writes_result_to_channel():
+    manager = SubAgentManager()
+    task_id = await manager.delegate(task="task1", tools=[], model="gpt-4o-mini", llm=StaticLLM())
+    channel = manager.get_channel(task_id)
+
+    result = await channel.get_result(timeout=1)
+
+    assert result.task == "task1"
+    assert result.tool_call_id == f"subagent_{task_id}"
+    assert result.result == "subagent done"
+    assert task_id not in manager.list_subagents()
+
+
+@pytest.mark.asyncio
+async def test_subagent_without_llm_writes_result_to_channel():
+    manager = SubAgentManager()
+    task_id = await manager.delegate(task="task1", tools=[], model="gpt-4o-mini", llm=None)
+    channel = manager.get_channel(task_id)
+
+    result = await channel.get_result(timeout=1)
+
+    assert result.task == "task1"
+    assert "LLM not configured" in result.result
+
+
+@pytest.mark.asyncio
+async def test_subagent_llm_exception_writes_error_to_channel():
+    manager = SubAgentManager()
+    task_id = await manager.delegate(task="task1", tools=[], model="gpt-4o-mini", llm=FailingLLM())
+    channel = manager.get_channel(task_id)
+
+    result = await channel.get_result(timeout=1)
+
+    assert result.task == "task1"
+    assert "[Error] llm failed" in result.result
 
 @pytest.mark.asyncio
 async def test_cancel_subagent():
     manager = SubAgentManager()
-    task_id = await manager.delegate(task="long task", tools=[], model="gpt-4o-mini", llm=None)
+    task_id = await manager.delegate(task="long task", tools=[], model="gpt-4o-mini", llm=SlowLLM())
     cancelled = await manager.cancel(task_id)
     assert cancelled is True
     assert task_id not in manager.list_subagents()

--- a/tests/agent/test_anthropic_llm.py
+++ b/tests/agent/test_anthropic_llm.py
@@ -262,6 +262,36 @@ async def test_anthropic_llm_tool_use_block_conversion():
         assert tool_result_msg["content"][0]["tool_use_id"] == "call_abc"
 
 
+@pytest.mark.asyncio
+async def test_anthropic_llm_nonstream_text_and_tool_use_stop_reason():
+    """Non-stream tool_use responses should map to stop_reason=tool_calls."""
+    llm = AnthropicLLM(api_key="test-key")
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_response = MagicMock()
+        mock_response.json = MagicMock(return_value={
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I will run a command."},
+                {"type": "tool_use", "id": "tool_1", "name": "Bash", "input": {"cmd": "pwd"}},
+            ],
+            "stop_reason": "tool_use",
+        })
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        response = await llm.chat([Message(role="user", content="where am I?")])
+
+        assert response.content == "I will run a command."
+        assert response.stop_reason == "tool_calls"
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].id == "tool_1"
+        assert response.tool_calls[0].name == "Bash"
+        assert _json.loads(response.tool_calls[0].arguments) == {"cmd": "pwd"}
+
+
 # ---------------------------------------------------------------------------
 # 流式 SSE 测试（stream=True）
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -6,6 +6,7 @@ from agent.llm import LLMResponse, ToolCallDelta
 from agent.tools.base import Tool, tool_parameters, ToolCall
 from agent.tools.registry import ToolRegistry
 from agent.hooks.manager import HookManager
+from agent.memory.manager import MemoryManager
 
 @tool_parameters(name="Echo", description="Echo back", parameters={"type": "object", "properties": {}, "required": []})
 class EchoTool(Tool):
@@ -115,6 +116,85 @@ async def test_agent_loop_max_iterations():
     result = await loop.run([Message(role="user", content="test")])
     assert result.stop_reason.value == "max_iterations"
     assert len(result.tool_calls_made) == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_max_iterations_does_not_promote_tool_result_to_assistant():
+    mock_llm = MockLLM(LLMResponse(
+        content=None,
+        tool_calls=[ToolCallDelta(id="c1", name="Echo", arguments="{}")]
+    ))
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    loop = AgentLoop(
+        llm=mock_llm,
+        tool_registry=registry,
+        hooks=HookManager(),
+        max_iterations=1,
+    )
+
+    messages = [Message(role="user", content="test")]
+    result = await loop.run(messages)
+
+    assert result.stop_reason.value == "max_iterations"
+    assert result.content == ""
+    assert messages[-1].role == "tool"
+    assert all(not (m.role == "assistant" and m.content == "echo!") for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_invalid_tool_arguments_return_tool_error():
+    class InvalidArgsThenDoneLLM:
+        def __init__(self):
+            self.call_count = 0
+
+        async def chat(self, messages, tools=None, model="gpt-4") -> LLMResponse:
+            self.call_count += 1
+            if self.call_count == 1:
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallDelta(id="c1", name="Echo", arguments="{bad json")],
+                    stop_reason="tool_calls",
+                )
+            return LLMResponse(content="recovered", stop_reason="end_turn")
+
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    loop = AgentLoop(
+        llm=InvalidArgsThenDoneLLM(),
+        tool_registry=registry,
+        hooks=HookManager(),
+    )
+
+    messages = [Message(role="user", content="test")]
+    result = await loop.run(messages)
+
+    assert result.content == "recovered"
+    assert result.tool_calls_made[0].arguments == {}
+    assert "invalid JSON tool arguments" in (result.tool_calls_made[0].result or "")
+    tool_messages = [m for m in messages if m.role == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].tool_call_id == "c1"
+    assert "Error" in tool_messages[0].content
+
+
+def test_memory_compaction_preserves_assistant_tool_result_chain():
+    mgr = MemoryManager(max_tokens=1, recent_window=1)
+    messages = [
+        Message(role="system", content="system"),
+        Message(role="user", content="old"),
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[ToolCallDelta(id="c1", name="Echo", arguments="{}")],
+        ),
+        Message(role="tool", content="echo!", tool_call_id="c1"),
+    ]
+
+    mgr.compact_if_needed(messages)
+
+    assert [m.role for m in messages] == ["system", "assistant", "tool"]
+    assert messages[1].tool_calls[0].id == messages[2].tool_call_id
 
 
 @pytest.mark.asyncio

--- a/tests/agent/tools/test_read_write_tools.py
+++ b/tests/agent/tools/test_read_write_tools.py
@@ -1,31 +1,69 @@
-# tests/agent/tools/test_builtin.py
 import pytest
-import asyncio
-from pathlib import Path
+from agent.tools.builtin.bash import BashTool
+from agent.tools.builtin.grep import GrepTool
 from agent.tools.builtin.read import ReadTool
 from agent.tools.builtin.write import WriteTool
 
-def test_read_file(tmp_path):
+
+@pytest.mark.asyncio
+async def test_read_file(tmp_path):
     f = tmp_path / "test.txt"
     f.write_text("hello world")
 
     tool = ReadTool()
-    result = asyncio.get_event_loop().run_until_complete(
-        tool.execute(path=str(f))
-    )
+    result = await tool.execute(path=str(f))
     assert result == "hello world"
 
-def test_read_file_not_found():
+
+@pytest.mark.asyncio
+async def test_read_file_not_found():
     tool = ReadTool()
-    result = asyncio.get_event_loop().run_until_complete(
-        tool.execute(path="/nonexistent/file.txt")
-    )
+    result = await tool.execute(path="/nonexistent/file.txt")
     assert "Error" in result or "not found" in result.lower()
 
-def test_write_file(tmp_path):
+
+@pytest.mark.asyncio
+async def test_read_directory_returns_error(tmp_path):
+    tool = ReadTool()
+    result = await tool.execute(path=str(tmp_path))
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_write_file(tmp_path):
     tool = WriteTool()
     file_path = tmp_path / "output.txt"
-    result = asyncio.get_event_loop().run_until_complete(
-        tool.execute(path=str(file_path), content="hello")
-    )
+    result = await tool.execute(path=str(file_path), content="hello")
+    assert "已写入" in result
     assert file_path.read_text() == "hello"
+
+
+@pytest.mark.asyncio
+async def test_write_directory_path_returns_error(tmp_path):
+    tool = WriteTool()
+    result = await tool.execute(path=str(tmp_path), content="hello")
+    assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_bash_timeout():
+    tool = BashTool()
+    result = await tool.execute(cmd="sleep 1", timeout=0.05)
+    assert "Timeout" in result
+
+
+@pytest.mark.asyncio
+async def test_bash_non_zero_exit():
+    tool = BashTool()
+    result = await tool.execute(cmd="sh -c 'echo failed >&2; exit 7'")
+    assert "[Exit 7]" in result
+    assert "failed" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_invalid_regex_returns_error(tmp_path):
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    tool = GrepTool()
+    result = await tool.execute(pattern="[", path=str(f))
+    assert "Error" in result

--- a/tests/agent/tools/test_registry.py
+++ b/tests/agent/tools/test_registry.py
@@ -1,6 +1,5 @@
 # tests/agent/tools/test_registry.py
 import pytest
-import asyncio
 from agent.tools.registry import ToolRegistry
 from agent.tools.base import Tool, tool_parameters, ToolCall
 
@@ -29,15 +28,18 @@ def test_get_sandbox_flag():
     registry.register(EchoTool())
     assert registry.get_sandbox("Echo") is False
 
-def test_execute_found():
+@pytest.mark.asyncio
+async def test_execute_found():
     registry = ToolRegistry()
     registry.register(EchoTool())
     call = ToolCall(id="c1", name="Echo", arguments={})
-    result = asyncio.get_event_loop().run_until_complete(registry.execute(call))
+    result = await registry.execute(call)
     assert result == "echo!"
 
-def test_execute_not_found():
+
+@pytest.mark.asyncio
+async def test_execute_not_found():
     registry = ToolRegistry()
     call = ToolCall(id="c1", name="NonExistent", arguments={})
     with pytest.raises(KeyError):
-        asyncio.get_event_loop().run_until_complete(registry.execute(call))
+        await registry.execute(call)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,49 @@
+from typer.testing import CliRunner
+
+import cli
+from agent.result import RunResult, StopReason
+
+
+class FakeAgent:
+    def __init__(self, content="mock response"):
+        self.max_iterations = None
+        self.messages = None
+        self.content = content
+
+    async def run(self, messages):
+        self.messages = messages
+        return RunResult(
+            content=self.content,
+            stop_reason=StopReason.END_TURN,
+            tool_calls_made=[],
+        )
+
+
+def test_cli_single_prompt_uses_mock_agent(monkeypatch):
+    fake = FakeAgent()
+    monkeypatch.setattr(cli, "build_agent", lambda model=None, provider="openai": fake)
+
+    result = CliRunner().invoke(cli.app, ["main", "hello", "--max-iterations", "3"])
+
+    assert result.exit_code == 0
+    assert "mock response" in result.stdout
+    assert fake.max_iterations == 3
+    assert fake.messages[-1].role == "user"
+    assert fake.messages[-1].content == "hello"
+
+
+def test_cli_single_prompt_requires_prompt():
+    result = CliRunner().invoke(cli.app, ["main"])
+
+    assert result.exit_code == 1
+    assert "PROMPT is required" in result.stderr
+
+
+def test_cli_missing_openai_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MYAGENT_MODEL", raising=False)
+
+    result = CliRunner().invoke(cli.app, ["main", "hello", "--provider", "openai"])
+
+    assert result.exit_code == 1
+    assert "OPENAI_API_KEY not set" in result.stderr

--- a/tests/web_tests/test_server.py
+++ b/tests/web_tests/test_server.py
@@ -2,8 +2,8 @@
 """Integration tests for FastAPI server (HTTP + WebSocket) with Mock LLM."""
 import os
 import pytest
-from unittest.mock import MagicMock
 from httpx import AsyncClient, ASGITransport
+from fastapi.testclient import TestClient
 
 from agent.llm import LLMResponse, ToolCallDelta
 from agent.tools.base import Tool, tool_parameters
@@ -116,37 +116,81 @@ async def test_static_files_served(app):
 
 @pytest.mark.asyncio
 async def test_websocket_chat_flow():
-    """WebSocket chat: connect → send message → receive events."""
+    """WebSocket chat: connect -> send message -> receive events."""
     old_debug = os.environ.get("MYAGENT_DEBUG", "")
     try:
         if "MYAGENT_DEBUG" in os.environ:
             del os.environ["MYAGENT_DEBUG"]
         mock_llm = MockLLM([LLMResponse(content="Hello from agent!")])
         app = create_app(mock_llm)
-        transport = ASGITransport(app=app)
 
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            async with client.stream("GET", "/ws/new") as response:
-                # Send chat message
-                # Use httpx WebSocket-like approach
-                pass
+        with TestClient(app) as client:
+            with client.websocket_connect("/ws/new") as ws:
+                created = ws.receive_json()
+                assert created["type"] == "session_created"
+
+                ws.send_json({"type": "chat", "content": "hello"})
+                events = []
+                while True:
+                    event = ws.receive_json()
+                    events.append(event)
+                    if event["type"] == "done":
+                        break
     finally:
         os.environ["MYAGENT_DEBUG"] = old_debug
-    # Skip: httpx doesn't fully support WebSocket over ASGITransport.
-    # The WebSocket flow is tested via the session tests and real browser tests.
-    pytest.skip("WebSocket over ASGITransport not fully supported; tested via browser tests")
+    assert [e["type"] for e in events] == ["llm_response", "done"]
+    assert events[-1]["data"]["content"] == "Hello from agent!"
 
 
-@pytest.mark.asyncio
-async def test_websocket_chat_via_raw(app):
-    """Test that WebSocket endpoint accepts connections."""
-    transport = ASGITransport(app=app)
-    # Just verify the endpoint exists and the app is functional
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/")
-        assert resp.status_code == 200
-        resp = await client.get("/api/debug-status")
-        assert resp.status_code == 200
+def test_websocket_ping_and_reset(app):
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/new") as ws:
+            created = ws.receive_json()
+            assert created["type"] == "session_created"
+            first_session = created["session_id"]
+
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+            ws.send_json({"type": "reset"})
+            reset = ws.receive_json()
+            assert reset["type"] == "session_created"
+            assert reset["session_id"] != first_session
+
+
+def test_websocket_tool_events():
+    old_debug = os.environ.get("MYAGENT_DEBUG", "")
+    try:
+        if "MYAGENT_DEBUG" in os.environ:
+            del os.environ["MYAGENT_DEBUG"]
+        mock_llm = MockLLM([
+            LLMResponse(
+                content=None,
+                tool_calls=[ToolCallDelta(id="c1", name="Bash", arguments='{"cmd": "printf websocket"}')],
+                stop_reason="tool_calls",
+            ),
+            LLMResponse(content="Done after tool", stop_reason="end_turn"),
+        ])
+        app = create_app(mock_llm)
+
+        with TestClient(app) as client:
+            with client.websocket_connect("/ws/new") as ws:
+                ws.receive_json()
+                ws.send_json({"type": "chat", "content": "run a command"})
+                events = []
+                while True:
+                    event = ws.receive_json()
+                    events.append(event)
+                    if event["type"] == "done":
+                        break
+    finally:
+        os.environ["MYAGENT_DEBUG"] = old_debug
+
+    event_types = [e["type"] for e in events]
+    assert "tool_call" in event_types
+    assert "tool_result" in event_types
+    tool_result = next(e for e in events if e["type"] == "tool_result")
+    assert tool_result["data"]["result"] == "websocket"
 
 
 @pytest.mark.asyncio
@@ -157,9 +201,18 @@ async def test_debug_websocket_events_enabled():
         os.environ["MYAGENT_DEBUG"] = "enabled"
         mock_llm = MockLLM([LLMResponse(content="Debug test")])
         app = create_app(mock_llm)
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/debug")
-            assert resp.status_code == 200
+        with TestClient(app) as client:
+            with client.websocket_connect("/ws/new") as ws:
+                ws.receive_json()
+                ws.send_json({"type": "chat", "content": "debug"})
+                events = []
+                while True:
+                    event = ws.receive_json()
+                    events.append(event)
+                    if event["type"] == "done":
+                        break
     finally:
         os.environ["MYAGENT_DEBUG"] = old_debug
+
+    assert any(e["type"] == "debug" and e["phase"] == "before_iteration" for e in events)
+    assert any(e["type"] == "debug" and e["phase"] == "after_llm_call" for e in events)

--- a/tests/web_tests/test_session.py
+++ b/tests/web_tests/test_session.py
@@ -273,6 +273,30 @@ async def test_debug_events_contain_full_messages():
 
 
 @pytest.mark.asyncio
+async def test_debug_events_include_incrementing_turns_across_chat_runs():
+    mock_llm = MockLLM([LLMResponse(content="One"), LLMResponse(content="Two")])
+    manager = SessionManager(debug_enabled=True)
+    session = make_session(AgentLoop(
+        llm=mock_llm, tool_registry=ToolRegistry(), hooks=HookManager(),
+    ))
+
+    events = []
+
+    async def collect(e):
+        events.append(e)
+
+    await manager.run_session(session, "first", ws_send=collect)
+    await manager.run_session(session, "second", ws_send=collect)
+
+    before_iter_events = [
+        e for e in events
+        if e["type"] == "debug" and e["phase"] == "before_iteration"
+    ]
+    assert [e["turn"] for e in before_iter_events] == [1, 2]
+    assert [e["iteration"] for e in before_iter_events] == [0, 0]
+
+
+@pytest.mark.asyncio
 async def test_debug_disabled_no_events():
     """When debug is disabled, no debug events are emitted."""
     mock_llm = MockLLM([LLMResponse(content="Hello")])

--- a/web/session.py
+++ b/web/session.py
@@ -23,6 +23,7 @@ class AgentSession:
         self.session_id = session_id
         self.agent = agent
         self.messages: list[Message] = []
+        self.debug_turn = 0
 
     def init_messages(self, system_prompt: Optional[str] = None):
         default_system = (
@@ -79,7 +80,15 @@ class SessionManager:
 
         # Add debug hook if debug is enabled
         if self.debug_enabled:
-            debug_hook = DebugHook(emit=lambda e: queue.put_nowait(e), force_enabled=True)
+            session.debug_turn += 1
+            debug_turn = session.debug_turn
+
+            def emit_debug(event: dict):
+                event = dict(event)
+                event["turn"] = debug_turn
+                queue.put_nowait(event)
+
+            debug_hook = DebugHook(emit=emit_debug, force_enabled=True)
             session.agent.hooks.hooks.append(debug_hook)
 
         session.messages.append(Message(role="user", content=user_message))

--- a/web/static/debug.js
+++ b/web/static/debug.js
@@ -15,19 +15,21 @@ const PHASE_LABELS = {
 };
 
 function renderDebug() {
-  for (const event of debugEvents) {
+  for (const [eventIndex, event] of debugEvents.entries()) {
     if (event.type !== 'debug') continue;
     const iter = event.iteration;
+    const turn = event.turn || 1;
     const phase = event.phase;
+    const blockKey = `${turn}:${iter}`;
 
-    if (!iterBlocks[iter]) {
-      iterBlocks[iter] = createIterationBlock(iter);
-      debugContent.appendChild(iterBlocks[iter].el);
+    if (!iterBlocks[blockKey]) {
+      iterBlocks[blockKey] = createIterationBlock(turn, iter);
+      debugContent.appendChild(iterBlocks[blockKey].el);
     }
 
-    const block = iterBlocks[iter];
-    if (block.renderedPhases.has(phase)) continue;
-    block.renderedPhases.add(phase);
+    const block = iterBlocks[blockKey];
+    if (block.renderedEvents.has(eventIndex)) continue;
+    block.renderedEvents.add(eventIndex);
 
     const section = renderPhase(phase, event.data);
     block.body.appendChild(section);
@@ -35,13 +37,13 @@ function renderDebug() {
   debugContent.scrollTop = debugContent.scrollHeight;
 }
 
-function createIterationBlock(iteration) {
+function createIterationBlock(turn, iteration) {
   const el = document.createElement('div');
   el.className = 'iteration-block';
 
   const header = document.createElement('div');
   header.className = 'iteration-header';
-  header.innerHTML = `第 ${iteration + 1} 轮迭代 <span>▶</span>`;
+  header.innerHTML = `第 ${turn} 次对话 · 第 ${iteration + 1} 轮迭代 <span>▶</span>`;
   header.addEventListener('click', () => {
     body.classList.toggle('collapsed');
     header.querySelector('span').textContent = body.classList.contains('collapsed') ? '▶' : '▼';
@@ -53,7 +55,7 @@ function createIterationBlock(iteration) {
   el.appendChild(header);
   el.appendChild(body);
 
-  return { el, body, renderedPhases: new Set() };
+  return { el, body, renderedEvents: new Set() };
 }
 
 function renderPhase(phase, data) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MyAgent Web UI</title>
-<link rel="stylesheet" href="/static/style.css?v=3">
+<link rel="stylesheet" href="/static/style.css?v=4">
 </head>
 <body>
 <div id="app">
@@ -34,7 +34,7 @@
   </main>
 </div>
 
-<script src="/static/chat.js?v=3"></script>
-<script src="/static/debug.js?v=3"></script>
+<script src="/static/chat.js?v=4"></script>
+<script src="/static/debug.js?v=4"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MyAgent Web UI</title>
-<link rel="stylesheet" href="/static/style.css?v=4">
+<link rel="stylesheet" href="/static/style.css?v=5">
 </head>
 <body>
 <div id="app">
@@ -34,7 +34,7 @@
   </main>
 </div>
 
-<script src="/static/chat.js?v=4"></script>
-<script src="/static/debug.js?v=4"></script>
+<script src="/static/chat.js?v=5"></script>
+<script src="/static/debug.js?v=5"></script>
 </body>
 </html>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -28,6 +28,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  min-height: 0;
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -35,6 +36,7 @@ body {
 /* Header */
 header {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 16px;
   padding: 12px 20px;
@@ -62,13 +64,14 @@ header h1 {
 #status { margin-left: auto; font-size: 0.8rem; color: var(--text2); }
 
 /* Views */
-main { flex: 1; overflow: hidden; }
-.view { display: none; height: 100%; flex-direction: column; }
+main { flex: 1; min-height: 0; overflow: hidden; }
+.view { display: none; height: 100%; min-height: 0; flex-direction: column; overflow: hidden; }
 .view.active { display: flex; }
 
 /* Chat View */
 #messages {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 20px;
   display: flex;
@@ -172,11 +175,16 @@ main { flex: 1; overflow: hidden; }
 /* Debug View */
 #debug-content {
   flex: 1;
+  min-height: 0;
+  height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 20px;
+  padding-bottom: 32px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  scroll-padding: 20px;
 }
 
 .iteration-block {
@@ -184,6 +192,7 @@ main { flex: 1; overflow: hidden; }
   border-radius: 10px;
   border: 1px solid var(--border);
   overflow: hidden;
+  flex-shrink: 0;
 }
 .iteration-header {
   padding: 10px 16px;
@@ -196,7 +205,7 @@ main { flex: 1; overflow: hidden; }
   align-items: center;
 }
 .iteration-header:hover { opacity: 0.9; }
-.iteration-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+.iteration-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
 .iteration-body.collapsed { display: none; }
 
 .debug-section {
@@ -215,7 +224,7 @@ main { flex: 1; overflow: hidden; }
   align-items: center;
   gap: 8px;
 }
-.debug-section-body { padding: 8px 12px; }
+.debug-section-body { padding: 8px 12px; min-width: 0; overflow-x: auto; }
 
 .msg-table { width: 100%; font-size: 0.8rem; border-collapse: collapse; }
 .msg-table th {
@@ -229,6 +238,7 @@ main { flex: 1; overflow: hidden; }
   padding: 6px 8px;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
+  word-break: break-word;
 }
 .role-badge {
   display: inline-block;
@@ -245,6 +255,13 @@ main { flex: 1; overflow: hidden; }
 
 .tool-event { font-size: 0.82rem; padding: 6px 10px; background: var(--surface2); border-radius: 4px; }
 .tool-event .name { color: var(--info); font-weight: 600; }
+
+#debug-content pre {
+  max-width: 100%;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 
 .phase-icon { font-size: 1rem; }
 


### PR DESCRIPTION
## Summary
- Fixes AgentLoop max-iteration behavior so the last tool result is not promoted into a fake assistant response.
- Preserves assistant tool-call/tool-result protocol chains during memory compaction.
- Maps Anthropic non-stream `tool_use` stop reasons to `tool_calls`.
- Makes subagent result publication explicit across success, missing LLM, and LLM exception paths.
- Adds key CLI, WebSocket, subagent, adapter, AgentLoop, and built-in tool regression coverage.
- Stabilizes pytest local imports and pytest-asyncio fixture loop scope.

## Testing
- `pytest -q` -> 101 passed, 7 skipped, 1 warning
- `python3 -m pytest -q` -> 101 passed, 7 skipped, 1 warning

## Manual Verification
- CLI smoke with a mocked agent confirmed single-prompt output path.
- Web UI smoke with a local Uvicorn server and mock LLM confirmed `/`, `/api/debug-status`, WebSocket session creation, chat, reset, and debug events with `MYAGENT_DEBUG=enabled`.

## Coverage Notes
This PR targets no known blocking defects plus key path coverage. It does not claim absolute absence of bugs or 100% full-feature coverage. Real API and Playwright E2E remain optional checks outside the default test gate.