### PR TITLE
Document local benchmark workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ uv sync --extra dev
 uv run pytest -q
 uv run python cli.py main "Hello"
 MYAGENT_DEBUG=enabled uv run python cli.py web --host 127.0.0.1 --port 8000
+uv run python cli.py benchmark benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/myagent-benchmark-smoke --fake-edit-file README.md --fake-old-string '# MyAgent' --fake-new-string '# MyAgent Coding Agent'
 ```
 
 Direct commands are also valid when the active Python environment already has dependencies installed:
@@ -59,11 +60,19 @@ playwright install chromium
 MYAGENT_DEBUG=enabled uv run pytest tests/web_tests/test_browser.py --run-real-api -v
 ```
 
+For benchmark changes, run the benchmark unit tests and a fake-runner smoke:
+
+```bash
+pytest -q tests/benchmark
+uv run python cli.py benchmark benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/myagent-benchmark-smoke --fake-edit-file README.md --fake-old-string '# MyAgent' --fake-new-string '# MyAgent Coding Agent'
+```
+
 ## Development Rules
 
 - Add or update regression tests for bug fixes.
 - Keep tool-call protocol chains valid: an assistant message with `tool_calls` must keep its matching `tool` result messages.
 - Do not make the `max_iterations` path fabricate a final assistant response from a tool result.
+- Treat benchmark `passed_with_warnings` as a test-passing result with agent-side issues such as `max_iterations`; do not count it as a clean pass.
 - Preserve debug UI behavior across multiple chat turns; AgentLoop iteration numbers restart per chat turn, so UI grouping must distinguish chat turns.
 - Keep `.codegraph/`, `.understand-anything/`, local `.env*`, logs, and other generated/local files out of commits unless explicitly requested.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,15 @@ uv run pytest -q
 # Run a specific test file
 uv run pytest tests/agent/tools/test_registry.py -v
 
+# Run local benchmark smoke
+uv run python cli.py benchmark benchmarks/tasks \
+  --agent fake \
+  --source-repo . \
+  --runs-dir /tmp/myagent-benchmark-smoke \
+  --fake-edit-file README.md \
+  --fake-old-string '# MyAgent' \
+  --fake-new-string '# MyAgent Coding Agent'
+
 # Run CLI (需要 .env 配置 OPENAI_API_KEY + MYAGENT_MODEL)
 uv run python cli.py main "用 Read 工具读 /tmp"
 
@@ -74,6 +83,28 @@ FastAPI + WebSocket server with vanilla JS frontend. Two views:
 - `web/session.py` — SessionManager: one AgentLoop + messages per session
 - `web/debug_hook.py` — DebugHook: captures iteration state, emitted via Hook protocol
 - `web/static/` — Vanilla HTML/CSS/JS frontend
+
+### Local Benchmark (`benchmarks/`)
+
+The benchmark harness runs coding-agent tasks in detached git worktrees, hides
+evaluator task files from the agent workspace, applies `test.patch` after the
+agent finishes, and writes artifacts under the configured runs directory.
+
+Relevant entry point:
+
+```bash
+uv run python cli.py benchmark benchmarks/tasks \
+  --agent fake \
+  --source-repo . \
+  --runs-dir /tmp/myagent-benchmark-smoke \
+  --fake-edit-file README.md \
+  --fake-old-string '# MyAgent' \
+  --fake-new-string '# MyAgent Coding Agent'
+```
+
+Result statuses are `passed`, `passed_with_warnings`, `failed`, and `error`.
+`passed_with_warnings` means hidden tests passed but the agent reported a
+non-clean run, commonly `max_iterations`.
 
 ### Adding New Capabilities
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ MYAGENT_LOG_LEVEL=DEBUG uv run python cli.py web --port 8000 --model deepseek-v4
 
 # 运行测试
 uv run pytest -q
+
+# 运行本地 coding-agent benchmark（fake runner smoke）
+uv run python cli.py benchmark benchmarks/tasks \
+  --agent fake \
+  --source-repo . \
+  --runs-dir /tmp/myagent-benchmark-smoke \
+  --fake-edit-file README.md \
+  --fake-old-string '# MyAgent' \
+  --fake-new-string '# MyAgent Coding Agent'
 ```
 
 `uv run` 不是业务运行的必需条件，而是推荐的环境隔离方式：它会使用 `uv` 管理的项目虚拟环境，依赖版本更可复现。如果你当前 shell 的 Python 环境已经安装好依赖，也可以直接运行等价命令，例如 `python3 cli.py main "Hello"` 或 `pytest -q`。
@@ -244,6 +253,41 @@ MYAGENT_LOG_LEVEL=DEBUG uv run python cli.py web --port 8000
 playwright install chromium
 MYAGENT_DEBUG=enabled uv run pytest tests/web_tests/test_browser.py --run-real-api -v
 ```
+
+## Local Benchmark
+
+MyAgent includes a local coding-agent benchmark harness and task pack under
+`benchmarks/`. The harness evaluates agents in detached git worktrees, applies
+hidden evaluator tests after the agent finishes, and writes per-task artifacts.
+
+Run the deterministic fake-runner smoke test:
+
+```bash
+uv run python cli.py benchmark benchmarks/tasks \
+  --agent fake \
+  --source-repo . \
+  --runs-dir /tmp/myagent-benchmark-smoke \
+  --fake-edit-file README.md \
+  --fake-old-string '# MyAgent' \
+  --fake-new-string '# MyAgent Coding Agent'
+```
+
+Run the real MyAgent runner manually when API credentials are configured:
+
+```bash
+MYAGENT_PROVIDER=openai OPENAI_API_KEY=... \
+uv run python cli.py benchmark benchmarks/tasks \
+  --agent myagent \
+  --source-repo . \
+  --runs-dir /tmp/myagent-benchmark-myagent \
+  --max-iterations 30
+```
+
+Each run writes `run.json`, `summary.md`, and task-level `result.json`,
+`trace.json`, `final.diff`, `test_output.txt`, and `runner.log`. Task statuses
+are `passed`, `passed_with_warnings`, `failed`, or `error`; warnings mean the
+hidden tests passed but the agent run still reported an issue such as
+`max_iterations`.
 
 ## 技术栈
 

--- a/benchmarks/tasks/README.md
+++ b/benchmarks/tasks/README.md
@@ -36,3 +36,16 @@ Each task contains:
 - `gold.patch`: reference implementation for analysis only.
 
 The benchmark grades by `test_command`, not by exact patch equality.
+
+Task statuses:
+
+- `passed`: hidden validation passed and the agent completed normally.
+- `passed_with_warnings`: hidden validation passed, but the agent reported a
+  non-fatal issue such as `max_iterations`.
+- `failed`: hidden validation ran and failed.
+- `error`: setup, patch application, or harness execution failed.
+
+The current P0 task pack intentionally separates harness health from model
+quality. A real MyAgent run may fail coding tasks while still proving that the
+benchmark harness created isolated worktrees, hid evaluator files, applied
+hidden tests, and wrote complete artifacts.

--- a/docs/benchmark-plan.md
+++ b/docs/benchmark-plan.md
@@ -357,6 +357,7 @@ benchmarks/runs/<run-id>/
   "ended_at": "2026-06-14T12:42:11Z",
   "task_count": 20,
   "passed": 13,
+  "warnings": 2,
   "failed": 7
 }
 ```
@@ -369,6 +370,7 @@ benchmarks/runs/<run-id>/
 | Task | Status | Time | Iterations | Tool Calls | Failure |
 |------|--------|------|------------|------------|---------|
 | myagent-001-edit-tool | passed | 82s | 5 | 17 | - |
+| myagent-002-benchmark-cli | passed_with_warnings | 104s | 20 | 29 | max_iterations |
 | myagent-002-policy-deny-env | failed | 120s | 8 | 22 | edit_validation |
 ```
 
@@ -378,7 +380,7 @@ First version metrics:
 
 | Metric | Meaning |
 |--------|---------|
-| `status` | `passed`, `failed`, or `error` |
+| `status` | `passed`, `passed_with_warnings`, `failed`, or `error` |
 | `duration_seconds` | Wall-clock runtime |
 | `iterations` | LLM iterations |
 | `tool_calls` | Total tool calls |
@@ -413,6 +415,11 @@ Initial categories:
 | `no_change` | Agent produced no meaningful diff |
 | `out_of_scope_change` | Agent changed denied or unrelated files |
 | `model_failure` | Agent stopped without a useful solution |
+
+`passed_with_warnings` is reserved for cases where the hidden validation command
+passed but the agent runner reported a non-clean outcome, such as
+`max_iterations`. This keeps product correctness separate from agent process
+quality.
 
 ## 13. First Task Set
 
@@ -537,11 +544,14 @@ keys, model behavior, and cost.
 
 ### P0: Self-Benchmark Skeleton
 
-- Task schema.
-- Worktree runner.
-- MyAgent runner.
-- Result files.
-- 3-5 local tasks.
+- Task schema. Implemented.
+- Worktree runner. Implemented.
+- MyAgent runner. Implemented.
+- Result files. Implemented.
+- 3-5 local tasks. Implemented with the P0 local task pack in
+  `benchmarks/tasks/`.
+- Warning status for test-passing but non-clean agent runs. Implemented as
+  `passed_with_warnings`.
 
 ### P1: Useful Evaluation
 

--- a/docs/coding-agent-roadmap.md
+++ b/docs/coding-agent-roadmap.md
@@ -1,6 +1,6 @@
 # MyAgent Coding Agent Roadmap
 
-**Status**: Draft
+**Status**: Draft, with P0 benchmark harness partially implemented
 **Date**: 2026-06-14
 
 ---
@@ -33,10 +33,13 @@ The current system already has useful agent infrastructure:
 | Memory | AutoCompact-style message compaction |
 | Subagents | Background delegation and parent channel injection |
 | Web UI | Chat UI and debug timeline support |
+| Benchmark harness | Local task schema, detached worktree runner, fake/shell/MyAgent adapters, hidden test patches, trace artifacts, and CLI entry point |
+| Coding tools | `Edit`, workspace-aware `Bash`, `InspectGitDiff`, and hardened write behavior |
 
-The missing piece is a coding-agent-specific runtime. Today the project can call
-tools, but it does not yet have strong semantics for repository boundaries,
-controlled edits, test loops, trace capture, or benchmark execution.
+The remaining gap is a stronger coding-agent runtime. The project now has a P0
+self-benchmark harness and basic coding tools, but real-agent benchmark runs
+still show failures where MyAgent explores the repository without producing a
+useful diff before `max_iterations`.
 
 ## 3. Core Product Thesis
 
@@ -137,7 +140,8 @@ It should instruct the model to:
 
 ### 4.4 TraceRecorder
 
-Trace recording should become a first-class coding-agent capability.
+Trace recording is now a first-class benchmark artifact and should continue to
+become a first-class interactive coding-agent capability.
 
 Default trace should store structured summaries:
 
@@ -189,8 +193,9 @@ Initial categories:
 | `out_of_scope_change` | Agent modified denied or unrelated files |
 | `model_failure` | Agent response did not make actionable progress |
 
-The taxonomy will be used by the benchmark system, but it belongs in the coding
-agent roadmap because agent behavior should make these failures observable.
+The benchmark system uses these categories in `result.json` and `summary.md`.
+`passed_with_warnings` is used when hidden tests pass but the agent runner still
+reports a non-clean outcome such as `max_iterations`.
 
 ## 5. Implementation Phases
 
@@ -200,12 +205,13 @@ Goal: make MyAgent safely edit code in a local repository and record what it did
 
 Deliverables:
 
-- `WorkspacePolicy` minimal implementation.
-- `EditTool` with exact replacement semantics.
-- `InspectGitDiffTool`.
-- Coding-agent system prompt.
-- TraceRecorder summary trace.
-- Tests for path policy, edit semantics, and diff inspection.
+- `WorkspacePolicy` minimal implementation. Done.
+- `EditTool` with exact replacement semantics. Done.
+- `InspectGitDiffTool`. Done.
+- Coding-agent system prompt. Partially done for benchmark runs.
+- TraceRecorder summary trace. Done for benchmark artifacts.
+- Tests for path policy, edit semantics, and diff inspection. Done.
+- Local benchmark task pack and CLI runner. Done.
 
 Interview talking point:
 


### PR DESCRIPTION
## Summary
- add benchmark usage instructions to README and agent guidance docs
- document run artifacts, task statuses, and `passed_with_warnings` semantics
- update benchmark plan and coding-agent roadmap to reflect the implemented P0 harness

## Validation
- `uv run pytest -q tests/benchmark tests/test_cli.py`

## Notes
- Generated `benchmarks/runs/` artifacts remain untracked and are not included.
