### PR TITLE
P2: Cross-agent benchmark with Claude Code

### DIFF
--- a/benchmarks/agent_runner.py
+++ b/benchmarks/agent_runner.py
@@ -155,6 +155,86 @@ class ShellCommandRunner(AgentRunner):
         )
 
 
+class ClaudeCodeRunner(AgentRunner):
+    """Subprocess adapter for the Claude Code CLI (`claude`).
+
+    Invokes ``claude -p`` (headless/print mode) inside the task worktree with
+    the raw issue content as the prompt.  Only the final git diff and the
+    stdout / stderr transcript are collected — no per-turn tool-call trace is
+    available from the external CLI.
+    """
+
+    def __init__(self, timeout_seconds: int = 600):
+        self.timeout_seconds = timeout_seconds
+
+    async def run(
+        self,
+        task: TaskSpec,
+        problem_statement: str,
+        workspace: Path,
+        output_dir: Path,
+        trace: TraceRecorder,
+    ) -> AgentRunResult:
+        start = time.time()
+
+        prompt = (
+            "You are working in a code repository.\n"
+            "Complete the following task:\n\n"
+            f"{problem_statement}\n\n"
+            "Verification command (run this before finishing):\n"
+            f"{task.test_command}"
+        )
+
+        env = os.environ.copy()
+        env.setdefault("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
+
+        cmd = [
+            "claude", "-p",
+            "--model", "deepseek-chat",
+            "--dangerously-skip-permissions",
+            "--output-format", "text",
+            prompt,
+        ]
+        trace.record_tool_call("ClaudeCode", {"cmd": " ".join(cmd[:5])})
+
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                env=env,
+            )
+
+        try:
+            result = await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired:
+            trace.record_tool_result(
+                "ClaudeCode", "timeout",
+                (time.time() - start) * 1000,
+                f"timeout after {self.timeout_seconds}s",
+            )
+            return AgentRunResult(
+                status="error",
+                failure_category=FailureCategory.TOOL_ERROR.value,
+                output="Claude Code timed out",
+            )
+
+        output = (result.stdout or "") + "\n" + (result.stderr or "")
+        trace.record_tool_result(
+            "ClaudeCode",
+            "ok" if result.returncode == 0 else "error",
+            (time.time() - start) * 1000,
+            output,
+        )
+        return AgentRunResult(
+            status="completed" if result.returncode == 0 else "error",
+            failure_category=None if result.returncode == 0 else FailureCategory.TOOL_ERROR.value,
+            output=output,
+        )
+
+
 class CountingLLM:
     def __init__(self, llm):
         self.llm = llm

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Comparison report generator for cross-agent benchmark runs.
+
+Usage:
+    python benchmarks/compare.py /tmp/bench-v4/<run-id> /tmp/p2-bench-claude/<run-id>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+RESULT_ORDER = ["passed", "passed_with_warnings", "failed", "error"]
+
+
+def _sort_key(status: str) -> int:
+    try:
+        return RESULT_ORDER.index(status)
+    except ValueError:
+        return 99
+
+
+def load_run(run_dir: Path) -> dict[str, dict]:
+    tasks = {}
+    tasks_dir = run_dir / "tasks"
+    if not tasks_dir.exists():
+        return tasks
+    for task_dir in sorted(tasks_dir.iterdir()):
+        result_path = task_dir / "result.json"
+        if result_path.exists():
+            data = json.loads(result_path.read_text())
+            tasks[task_dir.name] = data
+    return tasks
+
+
+def build_summary(runs: list[tuple[str, dict[str, dict]]]) -> str:
+    """Build a markdown comparison summary table."""
+    header = ["Task"]
+    for name, _ in runs:
+        header.append(f"{name}")
+    lines = [
+        "# Cross-Agent Benchmark Comparison",
+        "",
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join(["------"] * len(header)) + "|",
+    ]
+
+    all_tasks = sorted(set().union(*(r.keys() for _, r in runs)))
+    stats = defaultdict(lambda: defaultdict(int))
+
+    for task_id in all_tasks:
+        row = [task_id]
+        for name, results in runs:
+            r = results.get(task_id, {})
+            status = r.get("status", "?")
+            time_s = r.get("duration_seconds", "?")
+            row.append(f"{status} ({time_s}s)")
+            stats[name][status] += 1
+        lines.append("| " + " | ".join(row) + " |")
+
+    # Summary rows
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    header2 = ["Agent"] + RESULT_ORDER + ["Total"]
+    lines.append("| " + " | ".join(header2) + " |")
+    lines.append("|" + "|".join(["------"] * len(header2)) + "|")
+    for name, _ in runs:
+        s = stats[name]
+        total = sum(s.values())
+        row = [name] + [str(s.get(k, 0)) for k in RESULT_ORDER] + [str(total)]
+        lines.append("| " + " | ".join(row) + " |")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_html(runs: list[tuple[str, dict[str, dict]]]) -> str:
+    """Build an HTML comparison report."""
+    all_tasks = sorted(set().union(*(r.keys() for _, r in runs)))
+    stats = defaultdict(lambda: defaultdict(int))
+    for name, results in runs:
+        for r in results.values():
+            stats[name][r.get("status", "?")] += 1
+
+    rows_html = ""
+    for task_id in all_tasks:
+        cells = f"<td>{task_id}</td>"
+        for name, results in runs:
+            r = results.get(task_id, {})
+            status = r.get("status", "?")
+            time_s = r.get("duration_seconds", "?")
+            cls = status
+            cells += f'<td class="{cls}">{status}<br><small>{time_s}s</small></td>'
+        rows_html += f"<tr>{cells}</tr>"
+
+    summary_rows = ""
+    for name, _ in runs:
+        s = stats[name]
+        total = sum(s.values())
+        cells = f"<td>{name}</td>"
+        for k in RESULT_ORDER:
+            cells += f"<td>{s.get(k, 0)}</td>"
+        cells += f"<td><strong>{total}</strong></td>"
+        summary_rows += f"<tr>{cells}</tr>"
+
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Cross-Agent Benchmark</title>
+<style>
+body {{ font-family: system-ui, sans-serif; max-width: 1200px; margin: 2rem auto; padding: 0 1rem; }}
+h1 {{ color: #333; }}
+table {{ border-collapse: collapse; width: 100%; margin: 1rem 0; }}
+th, td {{ padding: 8px 12px; text-align: left; border-bottom: 1px solid #ddd; }}
+th {{ background: #f5f5f5; }}
+.passed {{ color: #22c55e; font-weight: bold; }}
+.passed_with_warnings {{ color: #eab308; }}
+.failed {{ color: #ef4444; }}
+.error {{ color: #a855f7; }}
+small {{ color: #888; font-weight: normal; }}
+.summary td {{ font-size: 1.1rem; }}
+</style></head><body>
+<h1>Cross-Agent Benchmark Comparison</h1>
+<table>
+<thead><tr><th>Task</th>{"".join(f"<th>{name}</th>" for name, _ in runs)}</tr></thead>
+<tbody>{rows_html}</tbody>
+</table>
+<h2>Summary</h2>
+<table class="summary">
+<thead><tr><th>Agent</th>{"".join(f"<th>{k}</th>" for k in RESULT_ORDER)}<th>Total</th></tr></thead>
+<tbody>{summary_rows}</tbody>
+</table>
+</body></html>"""
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <run-dir> [run-dir ...]")
+        sys.exit(1)
+
+    runs: list[tuple[str, dict[str, dict]]] = []
+    labels = []
+    for i, path in enumerate(sys.argv[1:]):
+        run_dir = Path(path)
+        results = load_run(run_dir)
+        if not results:
+            print(f"Warning: no results in {run_dir}", file=sys.stderr)
+            continue
+        # Try reading run.json for metadata, fall back to directory name
+        run_json = run_dir / "run.json"
+        if run_json.exists():
+            meta = json.loads(run_json.read_text())
+            name = f"{meta.get('agent', '?')}" + (f" ({meta.get('model', '')})" if meta.get('model') else "")
+        else:
+            name = run_dir.name
+        runs.append((name, results))
+
+    if not runs:
+        print("No runs with results found.", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir = Path("benchmarks/reports")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    md_path = out_dir / "comparison.md"
+    md_path.write_text(build_summary(runs))
+    print(f"Markdown: {md_path}")
+
+    html_path = out_dir / "comparison.html"
+    html_path.write_text(build_html(runs))
+    print(f"HTML:     {html_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reports/comparison.html
+++ b/benchmarks/reports/comparison.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Cross-Agent Benchmark</title>
+<style>
+body { font-family: system-ui, sans-serif; max-width: 1200px; margin: 2rem auto; padding: 0 1rem; }
+h1 { color: #333; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #ddd; }
+th { background: #f5f5f5; }
+.passed { color: #22c55e; font-weight: bold; }
+.passed_with_warnings { color: #eab308; }
+.failed { color: #ef4444; }
+.error { color: #a855f7; }
+small { color: #888; font-weight: normal; }
+.summary td { font-size: 1.1rem; }
+</style></head><body>
+<h1>Cross-Agent Benchmark Comparison</h1>
+<table>
+<thead><tr><th>Task</th><th>myagent</th><th>claude</th></tr></thead>
+<tbody><tr><td>myagent-001-tool-registry</td><td class="passed">passed<br><small>21.0s</small></td><td class="passed">passed<br><small>26.1s</small></td></tr><tr><td>myagent-002-myagent-runner</td><td class="failed">failed<br><small>119.2s</small></td><td class="failed">failed<br><small>275.3s</small></td></tr><tr><td>myagent-002-sandbox-executor</td><td class="failed">failed<br><small>301.3s</small></td><td class="passed_with_warnings">passed_with_warnings<br><small>601.2s</small></td></tr><tr><td>myagent-003-agentloop-trace</td><td class="failed">failed<br><small>66.3s</small></td><td class="failed">failed<br><small>166.5s</small></td></tr><tr><td>myagent-003-read-write-tools</td><td class="failed">failed<br><small>58.0s</small></td><td class="failed">failed<br><small>98.9s</small></td></tr><tr><td>myagent-004-benchmark-cli</td><td class="failed">failed<br><small>61.1s</small></td><td class="failed">failed<br><small>140.1s</small></td></tr><tr><td>myagent-004-harden-write</td><td class="failed">failed<br><small>39.7s</small></td><td class="failed">failed<br><small>22.4s</small></td></tr><tr><td>myagent-005-bash-workspace</td><td class="failed">failed<br><small>125.0s</small></td><td class="failed">failed<br><small>110.9s</small></td></tr><tr><td>myagent-006-memory-manager</td><td class="passed">passed<br><small>70.3s</small></td><td class="passed">passed<br><small>119.8s</small></td></tr><tr><td>myagent-007-skill-loader</td><td class="passed">passed<br><small>49.7s</small></td><td class="passed">passed<br><small>85.7s</small></td></tr><tr><td>myagent-008-parent-channel</td><td class="passed">passed<br><small>30.5s</small></td><td class="failed">failed<br><small>133.8s</small></td></tr><tr><td>myagent-009-subagent-manager</td><td class="passed">passed<br><small>172.3s</small></td><td class="failed">failed<br><small>146.1s</small></td></tr><tr><td>myagent-010-agent-loop</td><td class="passed">passed<br><small>54.4s</small></td><td class="passed">passed<br><small>100.2s</small></td></tr><tr><td>myagent-011-repeater-fix</td><td class="passed">passed<br><small>57.1s</small></td><td class="passed">passed<br><small>146.5s</small></td></tr><tr><td>myagent-012-sse-streaming</td><td class="failed">failed<br><small>198.0s</small></td><td class="failed">failed<br><small>355.3s</small></td></tr><tr><td>myagent-013-hook-manager</td><td class="passed">passed<br><small>68.6s</small></td><td class="passed">passed<br><small>51.9s</small></td></tr><tr><td>myagent-014-logging-tracing</td><td class="passed">passed<br><small>99.1s</small></td><td class="passed">passed<br><small>95.8s</small></td></tr><tr><td>myagent-015-retry-budget</td><td class="passed">passed<br><small>118.5s</small></td><td class="passed">passed<br><small>209.0s</small></td></tr><tr><td>myagent-017-interactive-fix</td><td class="failed">failed<br><small>107.8s</small></td><td class="failed">failed<br><small>223.6s</small></td></tr><tr><td>myagent-018-warning-passes</td><td class="failed">failed<br><small>51.6s</small></td><td class="failed">failed<br><small>85.0s</small></td></tr><tr><td>myagent-019-runner-timeout</td><td class="failed">failed<br><small>44.5s</small></td><td class="failed">failed<br><small>94.0s</small></td></tr><tr><td>myagent-020-close-clients</td><td class="failed">failed<br><small>125.9s</small></td><td class="failed">failed<br><small>67.4s</small></td></tr><tr><td>myagent-readme-title</td><td class="passed">passed<br><small>7.6s</small></td><td class="passed">passed<br><small>9.2s</small></td></tr></tbody>
+</table>
+<h2>Summary</h2>
+<table class="summary">
+<thead><tr><th>Agent</th><th>passed</th><th>passed_with_warnings</th><th>failed</th><th>error</th><th>Total</th></tr></thead>
+<tbody><tr><td>myagent</td><td>11</td><td>0</td><td>12</td><td>0</td><td><strong>23</strong></td></tr><tr><td>claude</td><td>9</td><td>1</td><td>13</td><td>0</td><td><strong>23</strong></td></tr></tbody>
+</table>
+</body></html>

--- a/benchmarks/reports/comparison.md
+++ b/benchmarks/reports/comparison.md
@@ -1,0 +1,34 @@
+# Cross-Agent Benchmark Comparison
+
+| Task | myagent | claude |
+|------|------|------|
+| myagent-001-tool-registry | passed (21.0s) | passed (26.1s) |
+| myagent-002-myagent-runner | failed (119.2s) | failed (275.3s) |
+| myagent-002-sandbox-executor | failed (301.3s) | passed_with_warnings (601.2s) |
+| myagent-003-agentloop-trace | failed (66.3s) | failed (166.5s) |
+| myagent-003-read-write-tools | failed (58.0s) | failed (98.9s) |
+| myagent-004-benchmark-cli | failed (61.1s) | failed (140.1s) |
+| myagent-004-harden-write | failed (39.7s) | failed (22.4s) |
+| myagent-005-bash-workspace | failed (125.0s) | failed (110.9s) |
+| myagent-006-memory-manager | passed (70.3s) | passed (119.8s) |
+| myagent-007-skill-loader | passed (49.7s) | passed (85.7s) |
+| myagent-008-parent-channel | passed (30.5s) | failed (133.8s) |
+| myagent-009-subagent-manager | passed (172.3s) | failed (146.1s) |
+| myagent-010-agent-loop | passed (54.4s) | passed (100.2s) |
+| myagent-011-repeater-fix | passed (57.1s) | passed (146.5s) |
+| myagent-012-sse-streaming | failed (198.0s) | failed (355.3s) |
+| myagent-013-hook-manager | passed (68.6s) | passed (51.9s) |
+| myagent-014-logging-tracing | passed (99.1s) | passed (95.8s) |
+| myagent-015-retry-budget | passed (118.5s) | passed (209.0s) |
+| myagent-017-interactive-fix | failed (107.8s) | failed (223.6s) |
+| myagent-018-warning-passes | failed (51.6s) | failed (85.0s) |
+| myagent-019-runner-timeout | failed (44.5s) | failed (94.0s) |
+| myagent-020-close-clients | failed (125.9s) | failed (67.4s) |
+| myagent-readme-title | passed (7.6s) | passed (9.2s) |
+
+## Summary
+
+| Agent | passed | passed_with_warnings | failed | error | Total |
+|------|------|------|------|------|------|
+| myagent | 11 | 0 | 12 | 0 | 23 |
+| claude | 9 | 1 | 13 | 0 | 23 |

--- a/cli.py
+++ b/cli.py
@@ -210,7 +210,7 @@ def web(
 @app.command()
 def benchmark(
     tasks_dir: Path = typer.Argument(..., help="包含 benchmark task 子目录的目录"),
-    agent: str = typer.Option("fake", "--agent", help="Runner: fake / shell / myagent"),
+    agent: str = typer.Option("fake", "--agent", help="Runner: fake / shell / myagent / claude"),
     source_repo: Path = typer.Option(Path("."), "--source-repo", help="被测 git repo"),
     runs_dir: Path = typer.Option(Path("benchmarks/runs"), "--runs-dir", help="benchmark 输出目录"),
     provider: str = typer.Option(
@@ -225,7 +225,7 @@ def benchmark(
     keep_worktrees: bool = typer.Option(False, "--keep-worktrees", help="保留任务 worktree 便于调试"),
 ):
     """运行本地 Coding Agent benchmark。"""
-    from benchmarks.agent_runner import FakeAgentRunner, MyAgentRunner, ShellCommandRunner
+    from benchmarks.agent_runner import ClaudeCodeRunner, FakeAgentRunner, MyAgentRunner, ShellCommandRunner
     from benchmarks.runner import BenchmarkRunner
 
     if agent == "fake":
@@ -239,6 +239,9 @@ def benchmark(
             typer.echo("Error: --shell-command is required for --agent shell", err=True)
             raise SystemExit(1)
         runner_impl = ShellCommandRunner(shell_command)
+    elif agent == "claude":
+        timeout_override = int(os.environ.get("MYAGENT_BENCHMARK_TIMEOUT", "600"))
+        runner_impl = ClaudeCodeRunner(timeout_seconds=timeout_override)
     elif agent == "myagent":
         llm = build_llm(provider, model)
         runner_impl = MyAgentRunner(
@@ -247,7 +250,7 @@ def benchmark(
             max_iterations=max_iterations,
         )
     else:
-        typer.echo("Error: --agent must be fake, shell, or myagent", err=True)
+        typer.echo("Error: --agent must be fake, shell, myagent, or claude", err=True)
         raise SystemExit(1)
 
     runner = BenchmarkRunner(

--- a/docs/coding-agent-roadmap.md
+++ b/docs/coding-agent-roadmap.md
@@ -286,13 +286,16 @@ Deliverables:
 
 - `ClaudeCodeRunner` — subprocess adapter that invokes `claude` CLI in the
   task worktree, passes the problem statement as a prompt, and captures the
-  final git diff and stdout log.
-- `CodexRunner` — same pattern for the `codex` CLI.
-- Unified comparison report (`summary.md` extended) — one table with
-  results from all agents on the same task set, making pass rate and
-  failure category differences visible.
+  final git diff and stdout log. Done.
+- `CodexRunner` — same pattern for the `codex` CLI. Deferred (authentication
+  complexity).
+- Unified comparison report — `benchmarks/compare.py` generates MD + HTML
+  side-by-side tables with pass rate and timing. Done.
 - Contract tests — each adapter satisfies `AgentRunner.run()`, so the
-  benchmark harness can treat Claude Code and Codex the same as MyAgent.
+  benchmark harness can treat Claude Code the same as MyAgent. Done.
+- First comparison results: MyAgent 11/23 (48%) vs Claude Code 9/23 (39%)
+  with same DeepSeek model — pass rates and failure modes overlap heavily,
+  suggesting the model is the bottleneck. Done.
 
 Design notes:
 


### PR DESCRIPTION
## Summary
- **ClaudeCodeRunner** — subprocess adapter for headless `claude -p`
- **--agent claude** CLI option, unified 600s timeout
- **compare.py** — generates MD + HTML comparison reports
- **First comparison**: MyAgent 11/23 (48%) vs Claude Code 9/23 (39%)
- Both agents use the same DeepSeek model — pass rates and failure modes overlap heavily, suggesting the model is the bottleneck

## Test plan
- [x] 175 tests pass (1 pre-existing failure in test_myagent_runner_timeout)
- [x] Claude Code runner smoke: readme-title + tool-registry both passed
- [x] Full benchmark: 23 tasks, 9 passed, 1 passed_with_warnings, 13 failed
- [x] Comparison reports generated at benchmarks/reports/

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)