### PR TITLE
实现会话和运行标识展示

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,11 @@ _避免_: 自然语言计划、任务队列、人工审批流
 **Plan Item**:
 Planning State 中的单个计划步骤，包含稳定标识、内容、状态和可选说明。
 _避免_: 整个计划、后台任务、工具调用记录
+
+**Session ID**:
+一次交互式会话的可复制标识；Web 中对应一个浏览器聊天会话，CLI 交互模式中对应一个 REPL 会话，未来 TUI 中对应一个 TUI 会话。
+_避免_: 单次 Agent 运行、benchmark 批次编号、鉴权凭证
+
+**Run ID**:
+一次 Agent 运行的可复制标识；同一个 Session ID 下可以产生多个 Run ID。
+_避免_: 交互式会话、benchmark 批次编号、分布式 tracing 标识

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -14,6 +14,7 @@ from agent.memory.manager import MemoryManager
 from agent.planning import PlanStatus, PlanningManager
 from agent.subagent.manager import SubAgentManager
 from agent.run_config import AgentRunConfig
+from agent.run_identity import new_run_id
 
 if TYPE_CHECKING:
     from agent.llm import LLM
@@ -90,13 +91,27 @@ class AgentLoop:
         messages: list[Message],
         on_event: Optional[Callable[[str, dict], Awaitable[None]]] = None,
         trace_recorder: Optional["TraceRecorder"] = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
     ) -> RunResult:
+        resolved_run_id = run_id or new_run_id()
+        if trace_recorder:
+            trace_recorder.set_run_identity(
+                session_id=session_id,
+                run_id=resolved_run_id,
+            )
         previous_on_event = self._active_on_event
         previous_trace_recorder = self._active_trace_recorder
         self._active_on_event = on_event
         self._active_trace_recorder = trace_recorder
         try:
-            return await self._run(messages, on_event, trace_recorder)
+            return await self._run(
+                messages,
+                on_event,
+                trace_recorder,
+                session_id=session_id,
+                run_id=resolved_run_id,
+            )
         finally:
             self._active_on_event = previous_on_event
             self._active_trace_recorder = previous_trace_recorder
@@ -106,15 +121,26 @@ class AgentLoop:
         messages: list[Message],
         on_event: Optional[Callable[[str, dict], Awaitable[None]]] = None,
         trace_recorder: Optional["TraceRecorder"] = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
     ) -> RunResult:
         tool_calls_made: list[ToolCallMade] = []
         mode = self.run_config.mode.value
 
+        logger.info(
+            "Agent run started mode=%s session_id=%s run_id=%s",
+            mode,
+            session_id or "",
+            run_id or "",
+        )
         await self.hooks.on_run_started(self.run_config)
         if trace_recorder:
             trace_recorder.record_run_started(mode)
         if on_event:
-            await on_event("run_started", {"mode": mode})
+            event_data = {"mode": mode, "run_id": run_id}
+            if session_id is not None:
+                event_data["session_id"] = session_id
+            await on_event("run_started", event_data)
 
         for iteration in range(self.max_iterations):
             await self.hooks.before_iteration(iteration, messages)

--- a/agent/run_identity.py
+++ b/agent/run_identity.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import uuid
+
+
+def new_session_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def new_run_id() -> str:
+    return uuid.uuid4().hex[:12]

--- a/agent/trace_recorder.py
+++ b/agent/trace_recorder.py
@@ -20,12 +20,27 @@ class TraceRecorder:
         task_id: str = "",
         full_trace: bool = False,
         mode: str = "build",
+        session_id: str | None = None,
+        run_id: str | None = None,
     ):
         self.task_id = task_id
         self.full_trace = full_trace  # retained for serialization compat only
         self.mode = mode
+        self.session_id = session_id
+        self.run_id = run_id
         self.steps: list[TraceStep] = []
         self.started_at = time.time()
+
+    def set_run_identity(
+        self,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        if session_id is not None:
+            self.session_id = session_id
+        if run_id is not None:
+            self.run_id = run_id
 
     def record(self, step_type: str, **data: Any) -> None:
         self.steps.append(
@@ -35,7 +50,12 @@ class TraceRecorder:
     def record_run_started(self, mode: str | None = None) -> None:
         if mode is not None:
             self.mode = mode
-        self.record("run_started", mode=self.mode)
+        data: dict[str, Any] = {"mode": self.mode}
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
+        if self.run_id is not None:
+            data["run_id"] = self.run_id
+        self.record("run_started", **data)
 
     def record_iteration(
         self,
@@ -108,13 +128,18 @@ class TraceRecorder:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data: dict[str, Any] = {
             "task_id": self.task_id,
             "mode": self.mode,
             "full_trace": self.full_trace,
             "duration_seconds": round(time.time() - self.started_at, 1),
-            "steps": [asdict(step) for step in self.steps],
         }
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
+        if self.run_id is not None:
+            data["run_id"] = self.run_id
+        data["steps"] = [asdict(step) for step in self.steps]
+        return data
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), indent=2, ensure_ascii=False)

--- a/benchmarks/agent_runner.py
+++ b/benchmarks/agent_runner.py
@@ -316,7 +316,12 @@ class MyAgentRunner(AgentRunner):
         effective_timeout = self.timeout_seconds
         try:
             result = await asyncio.wait_for(
-                agent.run(messages, trace_recorder=trace),
+                agent.run(
+                    messages,
+                    trace_recorder=trace,
+                    session_id=trace.session_id,
+                    run_id=trace.run_id,
+                ),
                 timeout=effective_timeout,
             )
         except asyncio.TimeoutError:

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -36,6 +36,7 @@ class TaskResult:
     agent: str
     model: str = ""
     mode: str = "build"
+    agent_run_id: str | None = None
     status: str = "error"
     test_exit_code: int | None = None
     duration_seconds: float = 0.0

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from agent.run_config import AgentRunConfig, parse_agent_mode
+from agent.run_identity import new_run_id as new_agent_run_id
 from agent.trace_recorder import TraceRecorder
 from benchmarks.agent_runner import AgentRunner
 from benchmarks.models import (
@@ -160,7 +161,12 @@ class BenchmarkRunner:
         )
 
         log_lines: list[str] = []
-        trace = TraceRecorder(task_id=loaded.task.id, mode=self.run_config.mode.value)
+        agent_run_id = new_agent_run_id()
+        trace = TraceRecorder(
+            task_id=loaded.task.id,
+            mode=self.run_config.mode.value,
+            run_id=agent_run_id,
+        )
         start = time.time()
         workspace: Path | None = None
         hidden_backup: Path | None = None
@@ -173,6 +179,7 @@ class BenchmarkRunner:
             agent=self.agent_name,
             model=self.model,
             mode=self.run_config.mode.value,
+            agent_run_id=agent_run_id,
         )
 
         try:
@@ -274,6 +281,7 @@ class BenchmarkRunner:
                 agent=self.agent_name,
                 model=self.model,
                 mode=self.run_config.mode.value,
+                agent_run_id=agent_run_id,
                 status=status,
                 test_exit_code=test_exit_code,
                 duration_seconds=round(time.time() - start, 1),

--- a/cli.py
+++ b/cli.py
@@ -33,6 +33,7 @@ from agent.hooks.manager import HookManager
 from agent.hooks.builtin import LoggingHook, TracingHook
 from agent.memory.manager import MemoryManager
 from agent.llm import LLM
+from agent.run_identity import new_run_id, new_session_id
 
 LOG_DIR = Path(__file__).parent / "logs"
 LOG_DIR.mkdir(exist_ok=True)
@@ -175,6 +176,8 @@ def run_single(
 ):
     agent = build_agent(model, provider, mode, config=config)
     agent.max_iterations = max_iterations
+    session_id = new_session_id()
+    run_id = new_run_id()
 
     messages: list[Message] = []
     if system:
@@ -188,7 +191,9 @@ def run_single(
     messages.append(Message(role="user", content=prompt))
 
     async def _run():
-        result = await agent.run(messages)
+        typer.echo(f"Session ID: {session_id}")
+        typer.echo(f"Run ID: {run_id}")
+        result = await agent.run(messages, session_id=session_id, run_id=run_id)
         typer.echo(f"\n【Agent】\n{result.content}")
         if result.tool_calls_made:
             typer.echo(f"\n【工具调用】{len(result.tool_calls_made)} 次")
@@ -207,9 +212,11 @@ def run_interactive(
 ):
     agent = build_agent(model, provider, mode, config=config)
     resolved_model = getattr(agent.llm, "model", model or "default")
+    session_id = new_session_id()
 
     typer.echo("MyAgent 交互模式 (输入 exit 退出)")
     typer.echo(f"模型: {resolved_model} | 提供商: {provider} | Mode: {mode}\n")
+    typer.echo(f"Session ID: {session_id}\n")
     agent.max_iterations = max_iterations
 
     messages: list[Message] = []
@@ -226,7 +233,9 @@ def run_interactive(
     asyncio.set_event_loop(loop)
 
     async def _run_async():
-        return await agent.run(messages)
+        run_id = new_run_id()
+        typer.echo(f"Run ID: {run_id}")
+        return await agent.run(messages, session_id=session_id, run_id=run_id)
 
     try:
         # 如果有初始 prompt，先跑一轮

--- a/openspec/changes/expose-session-run-identifiers/design.md
+++ b/openspec/changes/expose-session-run-identifiers/design.md
@@ -1,14 +1,14 @@
 ## Context
 
-当前 Web session id 主要存在于 WebSocket 路径和 session_created 事件中。CLI、日志、trace 和 benchmark 没有统一展示同一个排查标识。
+当前 Web session id 主要存在于 WebSocket 路径和 session_created 事件中。CLI、日志、trace 和 benchmark 没有统一展示 session id / run id。
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - 用户能在 Web UI / CLI / TUI 看到可复制的标识。
-- 日志和 trace 能用该标识关联一次运行。
-- benchmark artifact 能记录该标识。
+- 日志和 trace 能用 run id 关联一次 Agent 运行。
+- benchmark artifact 能记录 Agent 运行标识，同时不改变 benchmark 批次 run id 的既有含义。
 
 **Non-Goals:**
 
@@ -18,22 +18,26 @@
 
 ## Decisions
 
-### Decision 1: 区分 session id、run id 和 correlation id
+### Decision 1: 只区分 session id 和 run id
 
-Web 长会话保留 session id；CLI 单次运行可以生成 run id；底层事件和日志使用 correlation id 关联。
+session id 表示一次交互式会话；run id 表示一次 AgentLoop 运行。同一个 session id 下可以产生多个 run id。CLI 单次运行是只有一个 session id 和一个 run id 的特殊情况。Web、CLI 交互模式和未来 TUI 都复用这组术语。
 
 ### Decision 2: 标识先用于排查，不作为权限边界
 
 这些 id 不承担鉴权或安全边界职责，只用于可观察性。
 
+### Decision 3: 不引入独立 correlation id
+
+correlation id 不作为独立概念或第三套生命周期存在。需要通用关联字段时，直接使用 session id 和 run id。
+
 ## Risks / Trade-offs
 
-- [Risk] id 术语混乱。Mitigation: 在 CONTEXT 或规格中明确 session/run/correlation 的边界。
+- [Risk] id 术语混乱。Mitigation: 在 CONTEXT 或规格中明确 session/run 的边界。
 - [Risk] 日志泄漏过多上下文。Mitigation: 只记录随机 id，不记录敏感 prompt。
 
 ## Testing Strategy
 
 - Web session 测试确认 session_created 和页面展示 id。
 - CLI 测试确认输出 run id。
-- Trace / benchmark 测试确认 artifact 包含 correlation id。
+- Trace / benchmark 测试确认 artifact 包含 session id / run id。
 - benchmark smoke 覆盖 artifact 写入链路。

--- a/openspec/changes/expose-session-run-identifiers/proposal.md
+++ b/openspec/changes/expose-session-run-identifiers/proposal.md
@@ -11,8 +11,8 @@
 
 - Web UI 显示当前 session id。
 - CLI 显示当前 run id 或 session id。
-- 未来 TUI 复用同一 correlation id。
-- 日志、trace 和 benchmark artifact 写入相同标识，便于排查。
+- 未来 TUI 复用同一 session id / run id 模型。
+- 日志、trace 和 benchmark artifact 写入 session id / run id，便于排查。
 
 ## Capabilities
 
@@ -22,7 +22,7 @@
 - `web-ui`: 展示 session id。
 - `cli`: 展示 run id。
 - `tui`: 未来 TUI 复用标识。
-- `benchmark`: artifact 记录 correlation id。
+- `benchmark`: artifact 记录 agent run id。
 
 ## Impact
 
@@ -33,4 +33,4 @@
   - `benchmarks/`
 - 影响测试：
   - CLI/Web/session/trace/benchmark 测试。
-- 后续需要统一术语：Web 长会话为 session id，单次运行为 run id，二者通过 correlation id 关联。
+- 后续需要统一术语：交互式会话为 session id，一次 Agent 运行为 run id；不引入独立 correlation id。

--- a/openspec/changes/expose-session-run-identifiers/specs/agent-runtime/spec.md
+++ b/openspec/changes/expose-session-run-identifiers/specs/agent-runtime/spec.md
@@ -1,11 +1,12 @@
 ## ADDED Requirements
 
-### Requirement: Agent runtime 提供可关联运行标识
+### Requirement: Agent runtime 提供 session id 和 run id
 
-Agent runtime SHALL 为 session 或 run 提供可关联标识，用于日志、事件、trace 和 UI 展示。
+Agent runtime SHALL 为一次 Agent 运行提供 run id，并在存在交互式会话时关联 session id，用于日志、事件、trace 和 UI 展示。
 
-#### Scenario: 运行事件包含 correlation id
+#### Scenario: 运行事件包含 run id
 
 - **GIVEN** AgentLoop 开始一次运行
 - **WHEN** runtime 发布运行事件
-- **THEN** 事件 SHOULD 包含可用于排查的 correlation id
+- **THEN** 事件 SHALL 包含可用于排查的 run id
+- **AND** 如果调用方提供了 session id，事件 SHALL 包含该 session id

--- a/openspec/changes/expose-session-run-identifiers/specs/benchmark/spec.md
+++ b/openspec/changes/expose-session-run-identifiers/specs/benchmark/spec.md
@@ -1,11 +1,13 @@
 ## ADDED Requirements
 
-### Requirement: benchmark artifact 记录 correlation id
+### Requirement: benchmark artifact 记录 Agent 运行标识
 
-Benchmark artifact SHALL 记录 agent run 的 correlation id，便于从 benchmark result 反查 trace 和日志。
+Benchmark artifact SHALL 记录 `agent_run_id`，便于从 benchmark result 反查 trace 和日志，同时 SHALL 保持 benchmark 批次 `run_id` 的既有含义。
 
 #### Scenario: benchmark 任务完成
 
 - **GIVEN** benchmark runner 完成一个任务
 - **WHEN** 写入 result 和 trace artifact
-- **THEN** artifact SHOULD 包含可关联运行标识
+- **THEN** task result artifact SHALL 包含 `agent_run_id`
+- **AND** trace artifact SHALL 包含 Agent 运行的 `run_id`
+- **AND** benchmark run metadata SHALL 继续使用既有 `run_id` 表示 benchmark 批次

--- a/openspec/changes/expose-session-run-identifiers/specs/cli/spec.md
+++ b/openspec/changes/expose-session-run-identifiers/specs/cli/spec.md
@@ -1,11 +1,18 @@
 ## ADDED Requirements
 
-### Requirement: CLI 展示 run id
+### Requirement: CLI 展示 session id 和 run id
 
-CLI SHALL 在运行开始时展示本次 run id 或等价 correlation id。
+CLI SHALL 在启动会话时展示 session id，并在每次 Agent 运行开始时展示 run id。
 
 #### Scenario: CLI 启动 agent
 
 - **GIVEN** 用户通过 CLI 启动 Agent
 - **WHEN** 运行开始
 - **THEN** CLI SHALL 输出可用于排查的 run id
+
+#### Scenario: CLI 交互模式复用 session id
+
+- **GIVEN** 用户通过 CLI 交互模式启动 Agent
+- **WHEN** 用户连续发送多轮消息
+- **THEN** CLI SHALL 为该交互会话保持同一个 session id
+- **AND** 每轮 Agent 运行 SHALL 输出新的 run id

--- a/openspec/changes/expose-session-run-identifiers/specs/tui/spec.md
+++ b/openspec/changes/expose-session-run-identifiers/specs/tui/spec.md
@@ -1,11 +1,12 @@
 ## ADDED Requirements
 
-### Requirement: 未来 TUI 展示 correlation id
+### Requirement: 未来 TUI 展示 session id 和 run id
 
-未来 TUI SHALL 展示当前 session 或 run 的 correlation id。
+未来 TUI SHALL 展示当前交互式 session id 和最近一次 Agent 运行的 run id。
 
 #### Scenario: TUI 启动 session
 
 - **GIVEN** 用户打开 TUI
 - **WHEN** 创建或恢复运行
-- **THEN** TUI SHALL 展示可用于日志关联的 id
+- **THEN** TUI SHALL 展示可用于日志关联的 session id
+- **AND** 当 Agent 运行开始时，TUI SHALL 展示 run id

--- a/openspec/changes/expose-session-run-identifiers/specs/web-ui/spec.md
+++ b/openspec/changes/expose-session-run-identifiers/specs/web-ui/spec.md
@@ -9,3 +9,13 @@ Web UI SHALL 展示当前 session id，便于用户复制并关联日志。
 - **GIVEN** WebSocket 创建新 session
 - **WHEN** 前端收到 session_created 事件
 - **THEN** 页面 SHALL 展示该 session id
+
+### Requirement: Web UI 接收 run id
+
+Web UI SHALL 接收每次 Agent 运行的 run id，便于把用户消息和运行日志关联。
+
+#### Scenario: Agent 运行开始后展示 run id
+
+- **GIVEN** 用户在 Web UI 发送消息
+- **WHEN** 前端收到 run_started 事件
+- **THEN** 页面 SHALL 展示该 run id

--- a/openspec/changes/expose-session-run-identifiers/tasks.md
+++ b/openspec/changes/expose-session-run-identifiers/tasks.md
@@ -1,24 +1,24 @@
 ## 1. 规格
 
-- [ ] 1.1 修改 agent-runtime 规格，定义 session/run/correlation id。
-- [ ] 1.2 修改 Web / CLI / TUI / benchmark 规格，定义展示和 artifact 记录要求。
-- [ ] 1.3 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，逐项确认标识边界、日志关联、测试策略和文档影响。
+- [x] 1.1 修改 agent-runtime 规格，定义 session/run id。
+- [x] 1.2 修改 Web / CLI / TUI / benchmark 规格，定义展示和 artifact 记录要求。
+- [x] 1.3 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，逐项确认标识边界、日志关联、测试策略和文档影响。
 
 ## 2. 测试
 
-- [ ] 2.1 新增 Web session id 展示和事件测试。
-- [ ] 2.2 新增 CLI run id 输出测试。
-- [ ] 2.3 新增 trace / benchmark artifact 标识测试。
+- [x] 2.1 新增 Web session id 展示和事件测试。
+- [x] 2.2 新增 CLI run id 输出测试。
+- [x] 2.3 新增 trace / benchmark artifact 标识测试。
 
 ## 3. 实现
 
-- [ ] 3.1 增加统一运行标识生成和传递。
-- [ ] 3.2 Web UI 展示 session id。
-- [ ] 3.3 CLI 展示 run id。
-- [ ] 3.4 trace / benchmark 写入 correlation id。
+- [x] 3.1 增加统一运行标识生成和传递。
+- [x] 3.2 Web UI 展示 session id。
+- [x] 3.3 CLI 展示 run id。
+- [x] 3.4 trace / benchmark 写入 session id / run id。
 
 ## 4. 验证
 
-- [ ] 4.1 运行 CLI/Web/trace/benchmark 相关测试。
-- [ ] 4.2 运行 OpenSpec strict validate。
-- [ ] 4.3 跑通至少一个 benchmark smoke。
+- [x] 4.1 运行 CLI/Web/trace/benchmark 相关测试。
+- [x] 4.2 运行 OpenSpec strict validate。
+- [x] 4.3 跑通至少一个 benchmark smoke。

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -517,9 +517,24 @@ async def test_agent_loop_emits_run_started_event_with_mode():
     )
     trace = TraceRecorder(task_id="trace-test")
 
-    await loop.run([Message(role="user", content="test")], on_event=on_event, trace_recorder=trace)
+    await loop.run(
+        [Message(role="user", content="test")],
+        on_event=on_event,
+        trace_recorder=trace,
+        session_id="session-1",
+        run_id="run-1",
+    )
 
-    assert events[0] == ("run_started", {"mode": "read_only"})
+    assert events[0] == (
+        "run_started",
+        {
+            "mode": "read_only",
+            "session_id": "session-1",
+            "run_id": "run-1",
+        },
+    )
+    assert trace.to_dict()["session_id"] == "session-1"
+    assert trace.to_dict()["run_id"] == "run-1"
     assert trace.to_dict()["mode"] == "read_only"
     assert trace.steps[0].type == "run_started"
 

--- a/tests/agent/test_trace_recorder.py
+++ b/tests/agent/test_trace_recorder.py
@@ -40,14 +40,23 @@ def test_trace_recorder_writes_json(tmp_path):
 
 
 def test_trace_recorder_records_mode_metadata_and_run_started():
-    recorder = TraceRecorder(task_id="task-1", mode="read_only")
+    recorder = TraceRecorder(
+        task_id="task-1",
+        mode="read_only",
+        session_id="session-1",
+        run_id="run-1",
+    )
     recorder.record_run_started()
 
     data = recorder.to_dict()
 
+    assert data["session_id"] == "session-1"
+    assert data["run_id"] == "run-1"
     assert data["mode"] == "read_only"
     assert data["steps"][0]["type"] == "run_started"
     assert data["steps"][0]["data"]["mode"] == "read_only"
+    assert data["steps"][0]["data"]["session_id"] == "session-1"
+    assert data["steps"][0]["data"]["run_id"] == "run-1"
 
 
 def test_trace_recorder_records_planning_state():

--- a/tests/benchmark/test_benchmark_runner.py
+++ b/tests/benchmark/test_benchmark_runner.py
@@ -117,10 +117,12 @@ async def test_benchmark_runner_writes_closed_loop_artifacts(repo, tmp_path):
     assert result["status"] == "passed"
     assert result["edit_count"] == 1
     assert result["mode"] == "build"
+    assert result["agent_run_id"]
     assert "planning_summary" not in result
 
     trace = json.loads((task_output / "trace.json").read_text())
     assert trace["mode"] == "build"
+    assert trace["run_id"] == result["agent_run_id"]
     step_types = [step["type"] for step in trace["steps"]]
     assert "tool_call" in step_types
     assert "edit" in step_types
@@ -133,6 +135,7 @@ async def test_benchmark_runner_writes_closed_loop_artifacts(repo, tmp_path):
 
     run = json.loads((run_dir / "run.json").read_text())
     assert run["mode"] == "build"
+    assert run["run_id"] == "run-1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,12 +6,17 @@ from agent.result import RunResult, StopReason
 
 class FakeAgent:
     def __init__(self, content="mock response"):
+        self.llm = type("FakeLLM", (), {"model": "fake-model"})()
         self.max_iterations = None
         self.messages = None
         self.content = content
+        self.session_ids = []
+        self.run_ids = []
 
-    async def run(self, messages):
+    async def run(self, messages, session_id=None, run_id=None):
         self.messages = messages
+        self.session_ids.append(session_id)
+        self.run_ids.append(run_id)
         return RunResult(
             content=self.content,
             stop_reason=StopReason.END_TURN,
@@ -34,6 +39,50 @@ def test_cli_single_prompt_uses_mock_agent(monkeypatch):
     assert fake.max_iterations == 3
     assert fake.messages[-1].role == "user"
     assert fake.messages[-1].content == "hello"
+
+
+def test_cli_single_prompt_prints_session_and_run_ids(monkeypatch):
+    fake = FakeAgent()
+    monkeypatch.setattr(
+        cli,
+        "build_agent",
+        lambda model=None, provider="openai", mode="build", config=None: fake,
+    )
+    monkeypatch.setattr(cli, "new_session_id", lambda: "session-test")
+    monkeypatch.setattr(cli, "new_run_id", lambda: "run-test")
+
+    result = CliRunner().invoke(cli.app, ["main", "hello"])
+
+    assert result.exit_code == 0
+    assert "Session ID: session-test" in result.stdout
+    assert "Run ID: run-test" in result.stdout
+    assert fake.session_ids == ["session-test"]
+    assert fake.run_ids == ["run-test"]
+
+
+def test_cli_interactive_reuses_session_id_and_prints_run_ids(monkeypatch):
+    fake = FakeAgent()
+    run_ids = iter(["run-1", "run-2"])
+    monkeypatch.setattr(
+        cli,
+        "build_agent",
+        lambda model=None, provider="openai", mode="build", config=None: fake,
+    )
+    monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
+    monkeypatch.setattr(cli, "new_run_id", lambda: next(run_ids))
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["main", "hello", "--interactive"],
+        input="again\nexit\n",
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.count("Session ID: session-interactive") == 1
+    assert "Run ID: run-1" in result.stdout
+    assert "Run ID: run-2" in result.stdout
+    assert fake.session_ids == ["session-interactive", "session-interactive"]
+    assert fake.run_ids == ["run-1", "run-2"]
 
 
 def test_cli_single_prompt_passes_normalized_mode(monkeypatch):

--- a/tests/web_tests/test_server.py
+++ b/tests/web_tests/test_server.py
@@ -1,6 +1,8 @@
 # tests/web/test_server.py
 """Integration tests for FastAPI server (HTTP + WebSocket) with Mock LLM."""
 import os
+from pathlib import Path
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 from fastapi.testclient import TestClient
@@ -131,6 +133,7 @@ async def test_websocket_chat_flow():
                 created = ws.receive_json()
                 assert created["type"] == "session_created"
                 assert created["mode"] == "build"
+                assert created["session_id"]
 
                 ws.send_json({"type": "chat", "content": "hello"})
                 events = []
@@ -142,7 +145,19 @@ async def test_websocket_chat_flow():
     finally:
         os.environ["MYAGENT_DEBUG"] = old_debug
     assert [e["type"] for e in events] == ["run_started", "llm_response", "done"]
+    assert events[0]["data"]["session_id"] == created["session_id"]
+    assert events[0]["data"]["run_id"]
     assert events[-1]["data"]["content"] == "Hello from agent!"
+
+
+def test_web_static_assets_include_session_and_run_display():
+    index = (Path(__file__).parents[2] / "web" / "static" / "index.html").read_text()
+    script = (Path(__file__).parents[2] / "web" / "static" / "chat.js").read_text()
+
+    assert 'id="session-id"' in index
+    assert 'id="run-id"' in index
+    assert "sessionIdEl.textContent" in script
+    assert "runIdEl.textContent" in script
 
 
 def test_websocket_session_created_includes_configured_mode():

--- a/web/session.py
+++ b/web/session.py
@@ -2,12 +2,12 @@
 """Session manager: one AgentLoop + message history per browser session."""
 import asyncio
 import logging
-import uuid
-from typing import Optional, AsyncGenerator
+from typing import Optional
 
 from agent.config import MyAgentConfig
 from agent.loop import AgentLoop
 from agent.message import Message, system_message
+from agent.run_identity import new_session_id
 from agent.run_config import AgentRunConfig, ModePolicy, parse_agent_mode
 from agent.tools.factory import build_default_tool_registry
 from agent.workspace_policy import WorkspacePolicy
@@ -54,7 +54,7 @@ class SessionManager:
         self.run_config = AgentRunConfig(mode=parse_agent_mode(resolved_mode))
 
     def create_session(self, llm, tools: Optional[list] = None) -> AgentSession:
-        session_id = uuid.uuid4().hex[:12]
+        session_id = new_session_id()
         registry = build_default_tool_registry(
             policy=WorkspacePolicy(
                 command_denylist=self.config.tools.command_denylist,
@@ -116,7 +116,11 @@ class SessionManager:
         # Run agent in background, send queued events through websocket
         async def run_agent():
             try:
-                await session.agent.run(session.messages, on_event=on_event)
+                await session.agent.run(
+                    session.messages,
+                    on_event=on_event,
+                    session_id=session.session_id,
+                )
             except Exception:
                 logger.exception("Session run failed")
             finally:

--- a/web/static/chat.js
+++ b/web/static/chat.js
@@ -12,6 +12,8 @@ const messagesEl = document.getElementById('messages');
 const userInput = document.getElementById('user-input');
 const sendBtn = document.getElementById('send-btn');
 const statusEl = document.getElementById('status');
+const sessionIdEl = document.getElementById('session-id');
+const runIdEl = document.getElementById('run-id');
 const debugTabBtn = document.getElementById('debug-tab');
 const planningPanel = document.getElementById('planning-panel');
 const planningItemsEl = document.getElementById('planning-items');
@@ -57,6 +59,18 @@ function handleEvent(event) {
   switch (event.type) {
     case 'session_created':
       sessionId = event.session_id;
+      sessionIdEl.textContent = sessionId;
+      runIdEl.textContent = 'none';
+      break;
+
+    case 'run_started':
+      if (event.data && event.data.session_id) {
+        sessionId = event.data.session_id;
+        sessionIdEl.textContent = sessionId;
+      }
+      if (event.data && event.data.run_id) {
+        runIdEl.textContent = event.data.run_id;
+      }
       break;
 
     case 'llm_response': {
@@ -94,10 +108,6 @@ function handleEvent(event) {
       if (typeof renderPlanningDebug === 'function') {
         renderPlanningDebug(event.data);
       }
-      break;
-
-    case 'session_created':
-      sessionId = event.session_id;
       break;
 
     case 'pong':

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -14,6 +14,10 @@
       <button class="tab active" data-tab="chat">Chat</button>
       <button class="tab" data-tab="debug" id="debug-tab" style="display:none">Debug</button>
     </nav>
+    <div id="identity-bar" aria-label="runtime identifiers">
+      <span>Session <code id="session-id">pending</code></span>
+      <span>Run <code id="run-id">none</code></span>
+    </div>
     <span id="status"></span>
   </header>
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -63,6 +63,28 @@ header h1 {
 }
 .tab:hover { background: var(--surface2); color: var(--text); }
 .tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+#identity-bar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+  color: var(--text2);
+  font-size: 0.78rem;
+}
+#identity-bar span {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
+#identity-bar code {
+  max-width: 12ch;
+  overflow: hidden;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 #status { margin-left: auto; font-size: 0.8rem; color: var(--text2); }
 
 /* Views */


### PR DESCRIPTION
## 变更内容

- 统一 session_id / run_id 语义：session_id 表示交互式会话，run_id 表示一次 Agent 运行，不引入独立 correlation id。
- AgentLoop run_started event 和 TraceRecorder 写入 session_id / run_id。
- CLI 单次运行和交互模式展示 session/run id；Web UI 展示当前 session 和最近 run。
- benchmark 保留批次 run_id，task result 新增 agent_run_id，trace 使用 Agent 运行 run_id。
- 更新 CONTEXT.md、OpenSpec change 规格和任务清单。

## 验证

- uv run python -m pytest -q
- uv run openspec validate expose-session-run-identifiers --strict
- benchmark smoke：1 task passed，确认 result.json 的 agent_run_id 与 trace.json 的 run_id 一致。