### PR TITLE
新增基础能力补全变更规划

### DIFF
--- a/docs/openspec-change-backlog.md
+++ b/docs/openspec-change-backlog.md
@@ -30,27 +30,69 @@
 
 - `add-swebench-docker-harness`：已合入，后续 benchmark 相关 change 可以直接复用 Docker preflight、`status + reason` 和 SWE-bench harness 路径。
 
-### 第三批：工具权限模型前置
+### 第三批：Coding Agent 基本操作面
 
-- `refine-tool-permission-model`：优先级最高，应在 MCP、browser 和后续自定义工具能力前完成，避免外部工具继续扩大 `dangerous` 语义。
+- `add-slash-command-framework`：最高优先级，先统一 CLI 交互命令入口，并补齐 `/help`、`/status`、`/mode`、`/clear`、`/compact` 等基本命令。
+- `integrate-skill-runtime`：依赖 slash command framework，把已有 SkillLoader 接入配置、运行时上下文和 `/skills` 可观测入口。
 
-### 第四批：语义 code intelligence 与 TUI
+### 第四批：工具权限模型前置
+
+- `refine-tool-permission-model`：应在 MCP、browser 和后续自定义工具能力前完成，避免外部工具继续扩大 `dangerous` 语义。
+
+### 第五批：MCP 与 TUI 基本扩展
 
 - `add-lsp-code-intelligence`：已合入并归档。
-- `add-minimal-tui-runtime-view`：建议在 planning state、streaming、runtime mode switching 和工具结果 display policy 稳定后做，复用统一运行事件和 mode transition。
-
-### 第五批：外部工具与高风险能力
-
 - `add-mcp-tool-adapter`：可提前做设计和 fake server 测试，但实现会碰 ToolRegistry 权限元数据，建议与 browser 能力错开合入。
+- `add-minimal-tui-runtime-view`：建议在 slash command、skills、工具权限模型、planning state、streaming、runtime mode switching 和工具结果 display policy 稳定后做，复用统一运行事件和 mode transition。
+
+### 第六批：高风险 browser 能力
+
 - `add-browser-use-safety-foundation`：风险高于 MCP，应在配置、mode policy、workspace safety 和工具权限模型稳定后做。
 
 ## 未实现队列
 
-### 1. `refine-tool-permission-model`
+### 1. `add-slash-command-framework`
 
 状态：未实现。
 
-批次：第三批前置，当前未实现队列最高优先级。
+批次：第三批，当前未实现队列最高优先级。
+
+建议顺序原因：
+
+- slash command 是 CLI 交互模式、未来 TUI 命令面板和 skills 可观测入口的共同操作面。
+- `/clear`、`/compact`、`/status` 是 coding agent 长会话的基本控制能力，当前 MemoryManager 已有底层能力但缺少用户入口。
+- 先统一 command registry，可以避免后续 `/skills`、权限状态、MCP 状态等命令继续散落在输入循环里。
+
+主要交付：
+
+- Slash command registry。
+- `/help`、`/exit`、`/status`、`/mode`、`/clear`、`/compact`。
+- CLI 交互测试和 MemoryManager 手动 clear/compact 行为定义。
+
+### 2. `integrate-skill-runtime`
+
+状态：未实现。
+
+批次：第三批，建议在 `add-slash-command-framework` 合入后实现。
+
+建议顺序原因：
+
+- 仓库已有 SkillLoader 和 skills spec，但尚未接入真实运行时。
+- Skills 是 coding agent 复用工作流的基础能力，应先于 MCP/browser 等外部扩展稳定下来。
+- `/skills` 和 `/skills reload` 应复用 slash command framework，因此实现顺序排在 slash command 之后。
+
+主要交付：
+
+- Skill roots 配置。
+- Runtime 加载 skills、always skill 注入、matched skill 当前 run 注入。
+- `/skills` 和 `/skills reload`。
+- 加载诊断和可观测记录。
+
+### 3. `refine-tool-permission-model`
+
+状态：未实现。
+
+批次：第四批前置。
 
 建议顺序原因：
 
@@ -66,25 +108,7 @@
 - legacy `read_only` / `dangerous` 兼容路径。
 - 配置和测试迁移策略。
 
-### 2. `add-minimal-tui-runtime-view`
-
-状态：未实现。
-
-批次：第四批，runtime mode switching 已合入；等待工具权限模型、工具结果 display policy 等其余依赖稳定后开始。
-
-建议顺序原因：
-
-- TUI 应复用已有 AgentLoop 事件、planning state、streaming、工具结果 display policy、tool permission metadata 和 mode transition，而不是定义另一套运行协议。
-- 放在这些基础能力之后，可以一次展示稳定的运行状态、工具调用、planning state、streaming 输出、mode 状态和工具权限信息。
-
-主要交付：
-
-- TUI 命令入口。
-- AgentLoop 事件流消费。
-- 对话、工具调用、planning state、最终回复、diff/test 摘要和 trace 路径展示。
-- 非交互环境 graceful failure 或降级。
-
-### 3. `add-mcp-tool-adapter`
+### 4. `add-mcp-tool-adapter`
 
 状态：未实现。
 
@@ -102,11 +126,29 @@
 - MCP schema 映射为 ToolRegistry schema。
 - MCP tool 执行、错误、超时和权限元数据。
 
-### 4. `add-browser-use-safety-foundation`
+### 5. `add-minimal-tui-runtime-view`
 
 状态：未实现。
 
-批次：第五批，建议在 MCP 或核心工具权限模型更稳定后开始。
+批次：第五批，runtime mode switching 已合入；等待 slash command、skills、工具权限模型、工具结果 display policy 等其余依赖稳定后开始。
+
+建议顺序原因：
+
+- TUI 应复用已有 AgentLoop 事件、planning state、streaming、工具结果 display policy、slash command registry、skill runtime、tool permission metadata 和 mode transition，而不是定义另一套运行协议。
+- 放在这些基础能力之后，可以一次展示稳定的运行状态、工具调用、planning state、streaming 输出、mode 状态和工具权限信息。
+
+主要交付：
+
+- TUI 命令入口。
+- AgentLoop 事件流消费。
+- 对话、工具调用、planning state、最终回复、diff/test 摘要和 trace 路径展示。
+- 非交互环境 graceful failure 或降级。
+
+### 6. `add-browser-use-safety-foundation`
+
+状态：未实现。
+
+批次：第六批，建议在 MCP 或核心工具权限模型更稳定后开始。
 
 建议顺序原因：
 

--- a/openspec/changes/add-slash-command-framework/design.md
+++ b/openspec/changes/add-slash-command-framework/design.md
@@ -1,0 +1,108 @@
+## Context
+
+当前 CLI 交互模式位于 `cli.py::run_interactive`。它直接在输入循环中处理裸 `exit/quit/q`，并用 `_handle_interactive_command` 内联解析 `/mode`。MemoryManager 已提供 `clear()` 和 `compact()`，但只有自动 compact 路径，没有用户主动触发命令。
+
+后续基本能力补全会继续增加交互入口：skills 需要 `/skills`，TUI 需要命令面板，MCP 和 browser 后续也可能需要状态/权限相关命令。先建立 command registry，可以避免每个入口重复解析。
+
+## Goals / Non-Goals
+
+Goals:
+
+- 建立最小 slash command registry。
+- 将 CLI 交互模式现有 `/mode` 迁移到 registry。
+- 增加 `/help`、`/exit`、`/status`、`/clear`、`/compact`。
+- 明确 `/clear` 和 `/compact` 对 MemoryManager 与当前 `messages` 列表的影响。
+- 保持现有 CLI 交互模式兼容，裸 `exit`、`quit`、`q` 仍可退出。
+
+Non-Goals:
+
+- 不实现 `/skills`，只为后续 change 预留注册机制。
+- 不实现 TUI 命令面板或 Web slash command。
+- 不改变 AgentLoop 的 tool-call 协议。
+- 不允许 LLM 通过 tool 自行执行 `/clear` 或 `/compact`。
+- 不引入复杂 autocomplete；未来 TUI 可单独增强。
+
+## Decisions
+
+### Decision 1: Slash command registry 独立于 CLI 输入循环
+
+新增 command registry 模块，命令以对象或 dataclass 注册，至少包含 name、aliases、usage、description 和 handler。CLI 输入循环只负责判断输入是否为 slash command，并把 session context 交给 registry 执行。
+
+理由：后续 TUI/Web 可以复用命令定义；测试也能绕开 `input()` 循环直接验证命令行为。
+
+### Decision 2: 命令返回结构化结果
+
+命令 handler 返回结构化结果，例如 message、continue_session、mutated_messages、metadata。CLI 首版把 message 渲染为文本。
+
+理由：`/exit`、`/clear`、`/compact` 都不只是输出文本，它们会影响会话控制或上下文状态。结构化结果比约定字符串更稳。
+
+### Decision 3: `/clear` 操作当前交互消息列表和 MemoryManager
+
+`/clear` SHALL 保留 system messages，移除当前交互会话中累计的 user/assistant/tool 消息，并调用 MemoryManager 的等价清理能力保持状态一致。
+
+理由：当前 CLI run 使用本地 `messages` 列表传入 AgentLoop；只清 MemoryManager 或只清本地列表都会造成用户观察和下轮上下文不一致。
+
+### Decision 4: `/compact` 主动压缩当前交互消息列表
+
+`/compact` SHALL 调用 MemoryManager 对当前 `messages` 列表执行 compact，即使未超过自动 token 阈值也允许用户主动请求。命令输出应说明是否执行压缩以及压缩后的消息数量；如无可压缩内容，应返回可读提示。
+
+理由：用户显式输入 `/compact` 时期待主动整理上下文，不应受自动阈值限制。自动 compact 仍由 AgentLoop 在运行前执行。
+
+### Decision 5: `/status` 首版只展示本地可得信息
+
+`/status` 展示 session id、当前 mode、provider、model、message count 和 token 估算。无法获取的字段显示为 unavailable 或省略。
+
+理由：先提供可稳定测试的信息；trace 路径、最新 run id、tool permission profile 等可在后续 change 扩展。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - `/clear`、`/compact` 并入本 change，不单独建第三个 change。
+  - `/skills` 不并入本 change 的首批命令，由 `integrate-skill-runtime` 后续接入。
+  - command registry 应独立于 CLI 输入循环，便于未来 TUI/Web 复用。
+  - `/clear` 和 `/compact` 不暴露为 LLM tool。
+- Options considered:
+  - 继续在 `run_interactive` 中用 if/else 解析每个命令。
+  - 新增独立 command registry。
+  - 把 `/skills` 一起实现。
+  - 先只做 `/help` 和 `/mode`，把 clear/compact 后置。
+- Rejected alternatives:
+  - 继续 if/else。原因：后续命令会快速增长，测试和帮助文本会分裂。
+  - 把 `/skills` 一起实现。原因：skills runtime 本身还需要配置、注入和匹配设计，混入会扩大首个 change。
+  - 后置 clear/compact。原因：用户已明确把 compact、clear 视为常见命令，且 MemoryManager 已具备基础能力。
+- Final confirmations:
+  - 第一批命令为 `/help`、`/exit`、`/status`、`/mode`、`/clear`、`/compact`。
+  - 裸 `exit/quit/q` 保持兼容。
+  - 实现前需要再次用 `grill-with-docs` 确认命令结果结构、MemoryManager 清理细节和测试矩阵。
+- Remaining risks:
+  - CLI 本地 `messages` 和 AgentLoop memory 双状态可能不一致，开发时必须用测试锁住。
+  - 主动 compact 是否强制摘要取决于 LLM 可用性，用户提示文案需要准确。
+
+## Risks / Trade-offs
+
+- [Risk] 过早设计通用 command abstraction 可能过度工程。Mitigation: 首版只覆盖 name/aliases/help/handler/result，避免复杂 plugin command。
+- [Risk] `/clear` 清理不彻底导致旧上下文泄漏到下一轮。Mitigation: 测试同时检查 CLI messages 和 MemoryManager。
+- [Risk] `/compact` 在无 LLM 时只裁剪上下文，用户可能误解为摘要。Mitigation: 输出明确说明 compact 方式和结果。
+- [Risk] 后续 TUI/Web 复用需求变化。Mitigation: 返回结构化结果，渲染留给入口层。
+
+## Testing Strategy
+
+- command registry 单元测试：
+  - 注册、别名、未知命令、帮助文本。
+  - 参数缺失和错误提示。
+- CLI 交互测试：
+  - `/help` 输出命令列表。
+  - `/mode read_only` 保持现有行为。
+  - `/mode bypass` 继续拒绝。
+  - `/exit` 和裸 `exit` 均退出。
+  - `/status` 展示 session/mode/model。
+  - `/clear` 后下一轮不携带历史 user 消息。
+  - `/compact` 调用 MemoryManager compact 并输出结果。
+- MemoryManager 测试：
+  - clear 保留 system messages。
+  - forced compact 在有/无 LLM 场景行为明确。
+- 验证：
+  - `uv run pytest tests/test_cli.py -q`
+  - 相关 memory/command 测试。
+  - `uv run pytest -q`
+  - OpenSpec strict validate 和 artifact checker。

--- a/openspec/changes/add-slash-command-framework/proposal.md
+++ b/openspec/changes/add-slash-command-framework/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+CLI 交互模式目前只有内联解析的 `/mode`，`exit/quit/q` 也只是特殊字符串判断。随着后续需要补齐 `/clear`、`/compact`、`/status`、`/skills`、TUI 命令面板和 Web 命令入口，如果继续在各入口里散写字符串判断，会出现以下问题：
+
+- 命令帮助、参数校验、错误提示和测试分散，新增命令容易行为不一致。
+- MemoryManager 已有 `clear()`、`compact()` 能力，但用户没有明确交互命令入口。
+- `compact`、`clear` 等上下文操作会影响会话历史，必须有统一的行为定义和验证。
+- 后续 skills runtime 需要 `/skills`、`/skills reload` 等命令，应该复用同一个 command registry，而不是单独解析。
+
+本 change 目标是先建立最小 slash command 框架，并补齐 coding agent 基本上下文命令。
+
+## Change Type
+
+- primary: feature
+- secondary: [refactor]
+
+## What Changes
+
+- 新增交互式 slash command registry，统一声明命令名、别名、帮助文本、参数解析、执行结果和是否继续会话。
+- CLI 交互模式 SHALL 通过 command registry 处理 slash commands，不再只内联识别 `/mode`。
+- 首批内置命令：
+  - `/help`：列出可用命令及简短说明。
+  - `/exit`、`/quit`：退出交互会话；保留裸 `exit`、`quit`、`q` 兼容。
+  - `/status`：展示 session id、当前 mode、模型、provider，以及可用时的 token/message 摘要。
+  - `/mode <build|read_only|plan>`：复用现有 mode transition 语义，继续拒绝 `bypass`。
+  - `/clear`：清空当前交互会话中的非 system 消息，保留 system prompt 和必要运行上下文。
+  - `/compact`：主动触发 MemoryManager compact，并输出是否压缩、压缩前后摘要或可读原因。
+- 本 change 不实现 `/skills`；`/skills` 由后续 `integrate-skill-runtime` 接入同一 command registry。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cli`: CLI 交互模式新增统一 slash command 框架和首批内置命令。
+- `memory-context`: 明确定义用户手动触发 clear/compact 的上下文行为。
+
+## Impact Analysis
+
+- 影响代码：
+  - `cli.py`
+  - 可能新增 `agent/commands/` 或等价 command registry 模块。
+  - `agent/memory/manager.py` 可能需要补充可报告的 clear/compact 结果。
+- 影响测试：
+  - `tests/test_cli.py`
+  - 新增 command registry 单元测试。
+  - MemoryManager clear/compact 入口测试。
+- 影响文档：
+  - `openspec/specs/cli/spec.md`
+  - `openspec/specs/memory-context/spec.md`
+  - `docs/development-guide.md`
+  - `docs/testing-guide.md`
+- 不影响：
+  - Web UI 命令输入。
+  - TUI 命令面板。
+  - skills 加载和匹配逻辑。
+  - MCP、browser 和工具权限模型。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: Slash command 和上下文命令是 coding agent 交互面的基础，应参考其他 agent 对命令注册、帮助、上下文压缩和退出/清空行为的处理。
+- research questions:
+  - 其他 coding-agent 是否将 slash command 列表集中声明，而不是散落在输入循环里？
+  - `/compact`、`/clear`、`/status` 这类上下文命令应属于 CLI/TUI 操作面还是 AgentLoop 工具？
+  - skills 相关命令是否应与 slash command 框架解耦？
+- findings:
+  - 当前环境没有可调用的 `codegraph` 命令，本次按流程降级使用 `rg` 和定点文件阅读。
+  - 本地参考仓库中 Claude Code 在提示中暴露 `/help` 等 slash command，并有 compact 相关服务；Nanobot README 记录 `/status`、context compact 和 skills；OpenClaw 文档记录 `/model`、`/models` 等会话命令；Pi TUI changelog 多次提到 slash-command autocomplete 和命令菜单。
+  - 这些参考实现支持把 slash command 作为独立交互层，而不是把每个命令硬编码在输入循环里。
+  - Skills 在 Claude Code、Hermes、Nanobot 中通常是单独能力域；命令只负责展示/刷新/调用入口，不应让 command registry 直接承担 skill 匹配。
+- design impact:
+  - 本 change 只做通用 command registry 和上下文命令，把 `/skills` 留给 skill runtime change。
+  - `/clear` 和 `/compact` 作为交互命令调用 MemoryManager，不建成 LLM 可调用 tool，避免模型自行清上下文。
+  - 命令处理结果应是结构化对象，方便未来 TUI/Web 复用，而 CLI 首版只做文本渲染。

--- a/openspec/changes/add-slash-command-framework/specs/cli/spec.md
+++ b/openspec/changes/add-slash-command-framework/specs/cli/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: CLI interactive slash command registry
+
+CLI interactive mode SHALL route slash commands through a central command registry.
+
+#### Scenario: Slash command help
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/help`
+- **THEN** CLI SHALL 输出可用 slash command 列表
+- **AND** 每个命令 SHALL 包含简短说明或用法
+
+#### Scenario: Unknown slash command
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入未知 slash command
+- **THEN** CLI SHALL 输出可读错误
+- **AND** SHALL NOT 将该输入发送给 LLM
+- **AND** 会话 SHALL 继续
+
+### Requirement: CLI interactive basic session commands
+
+CLI interactive mode SHALL provide basic session slash commands for exit, status, mode switching, clear, and compact.
+
+#### Scenario: Slash exit command
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/exit` 或 `/quit`
+- **THEN** CLI SHALL 结束交互会话
+
+#### Scenario: Bare exit remains compatible
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `exit`、`quit` 或 `q`
+- **THEN** CLI SHALL 结束交互会话
+
+#### Scenario: Slash status command
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/status`
+- **THEN** CLI SHALL 输出当前 session id、mode、provider 和 model
+- **AND** SHOULD 输出当前消息数量或 token 估算
+
+#### Scenario: Slash mode command uses registry
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/mode read_only`
+- **THEN** CLI SHALL 通过 slash command registry 调用统一 mode transition
+- **AND** 后续 run SHALL 使用 `read_only`
+
+#### Scenario: Slash clear command
+
+- **GIVEN** 用户处于 CLI 交互模式并已有多轮对话
+- **WHEN** 用户输入 `/clear`
+- **THEN** CLI SHALL 清空当前会话的非 system 消息
+- **AND** 输出可读确认
+- **AND** SHALL NOT 将 `/clear` 发送给 LLM
+
+#### Scenario: Slash compact command
+
+- **GIVEN** 用户处于 CLI 交互模式并已有多轮对话
+- **WHEN** 用户输入 `/compact`
+- **THEN** CLI SHALL 主动请求压缩当前会话上下文
+- **AND** 输出压缩结果或无需压缩的可读说明
+- **AND** SHALL NOT 将 `/compact` 发送给 LLM

--- a/openspec/changes/add-slash-command-framework/specs/memory-context/spec.md
+++ b/openspec/changes/add-slash-command-framework/specs/memory-context/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Manual clear keeps system context
+
+MemoryManager SHALL support manual clearing of conversation history while preserving system messages.
+
+#### Scenario: Manual clear removes non-system messages
+
+- **GIVEN** conversation memory contains system, user, assistant, and tool messages
+- **WHEN** manual clear is requested
+- **THEN** memory SHALL retain system messages
+- **AND** remove non-system messages
+
+### Requirement: Manual compact can be forced
+
+MemoryManager SHALL support a manual compact operation for the current conversation history.
+
+#### Scenario: Manual compact requested under token budget
+
+- **GIVEN** conversation history is below the automatic compact token threshold
+- **WHEN** the user manually requests compact
+- **THEN** the system SHALL either compact eligible older messages or return a clear no-op result
+- **AND** the result SHALL be observable by the caller
+
+#### Scenario: Manual compact preserves tool-call chains
+
+- **GIVEN** conversation history contains assistant tool calls and tool results
+- **WHEN** manual compact is requested
+- **THEN** compact SHALL preserve provider-valid tool-call chains using the same invariant as automatic compact

--- a/openspec/changes/add-slash-command-framework/tasks.md
+++ b/openspec/changes/add-slash-command-framework/tasks.md
@@ -1,0 +1,44 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `cli` spec delta，定义 slash command registry 和首批命令。
+- [ ] 1.2 更新 `memory-context` spec delta，定义手动 `/clear` 和 `/compact` 行为。
+- [ ] 1.3 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.4 明确本 change 不包含 `/skills`、TUI 命令面板或 Web 命令入口。
+- [ ] 1.5 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，逐项确认 command result 结构、CLI 消息状态、MemoryManager 状态、错误提示、测试策略和文档影响。
+- [ ] 1.6 维护 `## Impact Analysis`，列出影响、不影响和待确认影响面；开发前把待确认项清理为明确结论或阻塞项。
+- [ ] 1.7 维护 `## Reference Implementation Research`；开发前补充更具体的参考实现文件和设计影响。
+- [ ] 1.8 在 `design.md` 的 `## Pre-Implementation Review` 记录已解决问题、备选方案、否决方案、最终确认和剩余风险。
+
+## 2. 测试
+
+- [ ] 2.1 新增 command registry 单元测试，覆盖注册、别名、未知命令、帮助文本和参数错误。
+- [ ] 2.2 新增 CLI 交互测试，覆盖 `/help`、`/exit`、裸 `exit`、`/status`、`/mode`。
+- [ ] 2.3 新增 CLI 交互测试，覆盖 `/clear` 清理当前会话历史。
+- [ ] 2.4 新增 CLI 交互测试，覆盖 `/compact` 主动触发 MemoryManager compact。
+- [ ] 2.5 新增或调整 MemoryManager 测试，覆盖手动 clear/forced compact 的可观测结果。
+
+## 3. 实现
+
+- [ ] 3.1 新增最小 slash command registry 和 command result 类型。
+- [ ] 3.2 将 CLI 交互模式接入 command registry。
+- [ ] 3.3 迁移现有 `/mode` 行为，并保留裸 `exit/quit/q` 兼容。
+- [ ] 3.4 实现 `/help`、`/exit`、`/status`。
+- [ ] 3.5 实现 `/clear` 和 `/compact`，确保当前 messages 与 MemoryManager 状态一致。
+- [ ] 3.6 更新必要文档。
+
+## 4. 验证
+
+- [ ] 4.1 运行 CLI 和 command registry 相关测试。
+- [ ] 4.2 运行 memory 相关测试。
+- [ ] 4.3 运行全量测试。
+- [ ] 4.4 运行 OpenSpec strict validate。
+- [ ] 4.5 运行项目 OpenSpec artifact checker。
+- [ ] 4.6 如实现触碰 AgentLoop 或工具协议，跑通至少一个 benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前，将本 change 归档到 `openspec/changes/archive/YYYY-MM-DD-add-slash-command-framework/`。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change，并同步并行开发批次。
+- [ ] 5.3 确认 Impact Analysis 不再残留未解释的 `unknown`、`TBD` 或 `待确认`。
+- [ ] 5.4 确认 Reference Implementation Research 已记录最终调研状态、发现和设计影响，且没有把本地参考仓库路径写成项目依赖。
+- [ ] 5.5 运行 `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict` 和 `uv run python scripts/check_openspec_artifacts.py`。

--- a/openspec/changes/integrate-skill-runtime/design.md
+++ b/openspec/changes/integrate-skill-runtime/design.md
@@ -1,0 +1,110 @@
+## Context
+
+当前 `SkillLoader` 可以从目录读取 `*.md`、解析 frontmatter、返回 `Skill` 对象，并提供 always skill 的系统提示拼接和基于 description 的简单匹配。但它没有被 `build_agent`、AgentLoop 或 CLI 默认路径使用。配置文件也没有 skill roots。
+
+这意味着当前 `skills` capability 的 current spec 已定义 loader 行为，但还没有覆盖“运行时如何加载、匹配、注入、观察和刷新”。
+
+## Goals / Non-Goals
+
+Goals:
+
+- 增加 skill roots 配置。
+- Agent/CLI 运行时加载 configured skills。
+- always skills 注入系统提示。
+- 普通 skills 根据当前用户输入匹配，并注入当前 run 上下文。
+- 提供 `/skills` 和 `/skills reload` 作为 CLI 可观测/刷新入口。
+- 保持无效 skill 不阻塞 agent 启动，并保留诊断。
+
+Non-Goals:
+
+- 不创建 skill authoring 工具。
+- 不接入外部 skill marketplace。
+- 不做 embedding/semantic search。
+- 不实现 skill 权限隔离或工具 allowlist 细粒度 enforcement。
+- 不让 skills 修改 tool registry；skills 首版只影响提示上下文。
+
+## Decisions
+
+### Decision 1: Skill roots 进入统一配置
+
+新增配置字段，例如 `skills.roots`。默认可包含 repo-local `skills/`，用户可配置额外目录。路径展开支持 `~` 和环境变量。
+
+理由：当前仓库已有 `skills/` 目录；用户级或团队共享 skill 目录应通过配置接入，而不是硬编码在代码里。
+
+### Decision 2: Runtime 启动时加载，`/skills reload` 手动刷新
+
+首版在 Agent/CLI 启动时加载 skill roots，并允许 `/skills reload` 手动刷新。不做每轮自动扫描文件系统。
+
+理由：避免每轮文件系统扫描和不可控 prompt 变化；手动 reload 足够支持开发调试。
+
+### Decision 3: Always skills 注入基础 system prompt
+
+always skill 的 prompt SHALL 注入 Agent 系统提示，使每轮都可见。注入内容应带 skill 名称边界，便于 trace 和调试。
+
+理由：always skill 表示全局行为约束或长期工作流，应稳定出现在运行上下文。
+
+### Decision 4: Matched skills 注入当前 run 的临时上下文
+
+普通 skill 基于当前用户输入匹配后，只注入当前 run，不永久追加到 memory。首版沿用现有 description 包含匹配；后续可单独增强匹配算法。
+
+理由：用户一次任务相关的 skill 不应污染后续所有对话；匹配算法先保持简单可测。
+
+### Decision 5: `/skills` 只做观察和 reload
+
+`/skills` 输出当前已加载 skill、来源、always 标记和最近一次加载诊断。`/skills reload` 重新加载 configured roots。它不直接触发某个 skill，也不绕过匹配机制。
+
+理由：保持 skill runtime 行为统一，避免用户命令和自动匹配产生两套注入路径。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - Skills runtime 单独建 change，不混入 slash command 框架。
+  - `/skills` 依赖 slash command registry，因此实现顺序在 `add-slash-command-framework` 之后。
+  - 首版只做本地 skill runtime，不做 marketplace、install 或 authoring。
+  - Skills 首版只影响 prompt context，不修改 ToolRegistry 权限。
+- Options considered:
+  - 每轮动态扫描 skill roots。
+  - 启动时加载并提供手动 reload。
+  - 将 matched skill 永久写入 memory。
+  - 将 matched skill 作为当前 run 临时上下文。
+  - 一并实现 skill marketplace/install。
+- Rejected alternatives:
+  - 每轮扫描。原因：会引入不稳定 prompt 变化和性能开销。
+  - 永久写入 memory。原因：任务相关 skill 会污染后续对话。
+  - 同时实现 marketplace/install。原因：会扩大范围，基本能力补全阶段先做本地 runtime。
+- Final confirmations:
+  - 依赖 `add-slash-command-framework`。
+  - 默认配置应能加载 repo-local `skills/`。
+  - 实现前需要再次确认注入位置、trace 可观测字段、配置 schema 和测试矩阵。
+- Remaining risks:
+  - Prompt 注入位置如果放错，可能与系统提示、OpenSpec 规则或用户输入优先级冲突。
+  - 简单 description 匹配可能召回差；首版接受，后续单独增强。
+
+## Risks / Trade-offs
+
+- [Risk] Skill prompt 注入过多导致上下文膨胀。Mitigation: 首版记录加载数量，必要时限制 matched skill 数量。
+- [Risk] 无效 skill 静默跳过导致用户不知道。Mitigation: 保留加载诊断并在 `/skills` 展示。
+- [Risk] Skills 影响行为但 trace 不可见。Mitigation: 记录 always/matched skill 名称到运行事件或 debug/trace。
+- [Risk] 配置路径泄漏到可提交文档。Mitigation: 文档只描述字段，不提交本地路径。
+
+## Testing Strategy
+
+- SkillLoader / runtime 测试：
+  - 多 root 加载、重复名称处理、无效 skill 诊断。
+  - always skill prompt 注入。
+  - matched skill 只注入当前 run。
+- 配置测试：
+  - `skills.roots` 解析、路径展开、默认值。
+  - 非列表或非法项 fail fast。
+- CLI 测试：
+  - `/skills` 列出已加载 skills。
+  - `/skills reload` 刷新目录并展示结果。
+- Agent run 测试：
+  - always skill 出现在 system context。
+  - query 命中普通 skill 时注入该 skill。
+  - 未命中时不注入普通 skill。
+- 验证：
+  - `uv run pytest tests/agent/skills -q`
+  - 相关 CLI/config/AgentLoop 测试。
+  - `uv run pytest -q`
+  - OpenSpec strict validate 和 artifact checker。

--- a/openspec/changes/integrate-skill-runtime/proposal.md
+++ b/openspec/changes/integrate-skill-runtime/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+仓库已有 `agent/skills/loader.py` 和 `openspec/specs/skills/spec.md`，但当前能力主要停留在 Markdown skill 加载器层面：默认 AgentLoop/CLI 运行时没有配置 skill roots、没有把 always skill 注入 system prompt，也没有按用户输入匹配普通 skill 或提供可观察的 skill 状态。
+
+如果不把 skills 接入真实运行时，后续 coding agent 的常用能力会缺一块：
+
+- 项目级或用户级工作流无法沉淀为可复用 skill。
+- agent 无法按任务自动加载相关 skill 指令。
+- 用户无法在交互会话中查看当前可用 skill 或刷新 skill 目录。
+- 后续 MCP、browser、review、TDD 等能力难以通过 skill 扩展形成轻量工作流。
+
+本 change 目标是把已有 SkillLoader 升级为可配置、可观测、可在 CLI/AgentLoop 中生效的 runtime skill capability。
+
+## Change Type
+
+- primary: feature
+- secondary: []
+
+## What Changes
+
+- 配置新增 skill roots，支持 repo-local 和用户级目录；路径展开应支持 `~` 和环境变量。
+- Agent 构造时 SHALL 加载 configured skill roots，跳过无效 skill 文件并保留诊断。
+- always skills SHALL 注入系统提示。
+- 普通 skills SHALL 基于用户输入匹配，并把匹配到的 skill prompt 注入当前 run 的上下文。
+- CLI slash command 框架接入后，新增：
+  - `/skills`：列出已加载 skills、来源和 always/matched 状态。
+  - `/skills reload`：重新加载 configured skill roots。
+- 本 change 不负责创建 skill、安装外部 skill marketplace 或复杂语义检索；只做本地 skill runtime。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills`: 从 loader 能力升级为 runtime skill loading、matching 和 prompt injection。
+- `configuration`: 增加 skill roots 配置。
+- `cli`: 增加 `/skills` 和 `/skills reload` 命令，依赖 slash command framework。
+
+## Impact Analysis
+
+- 影响代码：
+  - `agent/skills/loader.py`
+  - 可能新增 skill runtime/cache 模块。
+  - `agent/config.py`
+  - `cli.py` 和 slash command registry。
+  - Agent 构造或运行前 prompt 组装路径。
+- 影响测试：
+  - `tests/agent/skills/test_loader.py`
+  - 配置解析测试。
+  - CLI `/skills` 命令测试。
+  - Agent run/system prompt 注入测试。
+- 影响文档：
+  - `openspec/specs/skills/spec.md`
+  - `openspec/specs/configuration/spec.md`
+  - `openspec/specs/cli/spec.md`
+  - `docs/development-guide.md`
+  - `docs/architecture.md`
+- 依赖：
+  - 建议在 `add-slash-command-framework` 合入后实现，以复用 command registry。
+- 不影响：
+  - MCP adapter。
+  - browser/computer use。
+  - 外部 skill marketplace 或 skill 创建流程。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: Skills 是 coding agent 可扩展工作流的基础，应参考其他 agent 如何配置 skill roots、加载 Markdown skill、自动注入相关指令和提供可观察入口。
+- research questions:
+  - Skills 应在 Agent 构造时加载，还是每轮按需加载？
+  - always skill 和 matched skill 应注入 system prompt、developer prompt 还是用户上下文附近？
+  - `/skills` 这类命令应只做展示/刷新，还是参与 skill 匹配？
+  - skill roots 是否需要区分 repo-local、user-global 和 external/shared？
+- findings:
+  - 当前环境没有可调用的 `codegraph` 命令，本次按流程降级使用 `rg` 和定点文件阅读。
+  - Claude Code 提示中存在 skills 自动 surfaced/reminder 和 skill discovery 相关指令；Hermes 配置示例包含 external skill directories、local skills precedence 和 skill creation nudges；Nanobot 文档将 skills 作为核心上下文能力；OpenClaw 将 skills 作为扩展/插件生态的一部分。
+  - 参考实现倾向于把 skills 作为 runtime context 能力，而不是单纯 CLI 命令；CLI 命令主要提供列表、刷新、安装或调试入口。
+  - 多个参考实现区分用户级/共享 skill 目录，说明 Asterwynd 需要配置 skill roots，而不应只写死单个 repo 目录。
+- design impact:
+  - 本 change 以 runtime skill roots、always injection、matched injection 和 `/skills` 可观测为最小闭环。
+  - skill runtime 依赖 slash command framework，但不把 command registry 与 skill matching 强耦合。
+  - 首版使用现有 loader 的 Markdown 格式，不引入 marketplace、安装器或向量检索。

--- a/openspec/changes/integrate-skill-runtime/specs/cli/spec.md
+++ b/openspec/changes/integrate-skill-runtime/specs/cli/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: CLI exposes skill status commands
+
+CLI interactive mode SHALL expose slash commands for observing and reloading skills after the slash command framework exists.
+
+#### Scenario: List skills
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/skills`
+- **THEN** CLI SHALL 输出当前已加载 skills
+- **AND** 输出每个 skill 的名称、来源和 always 标记
+
+#### Scenario: Reload skills
+
+- **GIVEN** 用户处于 CLI 交互模式
+- **WHEN** 用户输入 `/skills reload`
+- **THEN** CLI SHALL 重新加载 configured skill roots
+- **AND** 输出加载数量和诊断摘要
+- **AND** 后续 run SHALL 使用刷新后的 skill set
+
+#### Scenario: Skill command requires slash command framework
+
+- **GIVEN** slash command framework 尚未实现
+- **WHEN** 本 change 准备进入实现
+- **THEN** implementation SHALL wait for or include the command registry dependency resolution

--- a/openspec/changes/integrate-skill-runtime/specs/configuration/spec.md
+++ b/openspec/changes/integrate-skill-runtime/specs/configuration/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Configuration declares skill roots
+
+Configuration SHALL allow users to declare local skill roots.
+
+#### Scenario: Skill roots configured
+
+- **GIVEN** configuration includes `skills.roots`
+- **WHEN** configuration is loaded
+- **THEN** each root SHALL be parsed as a filesystem path
+- **AND** `~` and environment variables SHOULD be expanded
+
+#### Scenario: Skill roots omitted
+
+- **GIVEN** configuration omits `skills.roots`
+- **WHEN** configuration is loaded
+- **THEN** the system SHOULD use a conservative default that includes repo-local skills when available
+
+#### Scenario: Invalid skill roots config
+
+- **GIVEN** `skills.roots` is not a list of strings
+- **WHEN** configuration is loaded
+- **THEN** configuration loading SHALL fail fast with a readable error

--- a/openspec/changes/integrate-skill-runtime/specs/skills/spec.md
+++ b/openspec/changes/integrate-skill-runtime/specs/skills/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Runtime loads configured skills
+
+The agent runtime SHALL load skills from configured skill roots before running user prompts.
+
+#### Scenario: Load skills from configured roots
+
+- **GIVEN** configuration declares one or more skill roots
+- **WHEN** the agent runtime starts
+- **THEN** it SHALL load valid Markdown skills from those roots
+- **AND** retain diagnostics for invalid skill files
+
+#### Scenario: Missing skill root
+
+- **GIVEN** a configured skill root does not exist
+- **WHEN** skills are loaded
+- **THEN** the runtime SHALL continue startup
+- **AND** record a diagnostic for that root
+
+### Requirement: Always skills are injected into system context
+
+Always skills SHALL be included in the agent system context for every run.
+
+#### Scenario: Always skill loaded
+
+- **GIVEN** a loaded skill has `always: true`
+- **WHEN** the agent builds system context
+- **THEN** the skill prompt SHALL be included with a clear skill name boundary
+
+### Requirement: Matched skills are injected for the current run
+
+Non-always skills SHALL be matched against the current user input and injected only for that run.
+
+#### Scenario: User input matches a skill
+
+- **GIVEN** a non-always skill matches the current user input
+- **WHEN** the agent runs that prompt
+- **THEN** the skill prompt SHALL be included in the current run context
+- **AND** it SHALL NOT be permanently appended to conversation memory
+
+#### Scenario: User input does not match a skill
+
+- **GIVEN** no non-always skill matches the current user input
+- **WHEN** the agent runs that prompt
+- **THEN** no non-always skill prompt SHALL be injected
+
+### Requirement: Skill reload refreshes runtime skills
+
+The runtime SHALL support manual reload of configured skill roots.
+
+#### Scenario: Reload skills
+
+- **GIVEN** the user requests skill reload
+- **WHEN** the runtime reloads skills
+- **THEN** subsequent runs SHALL use the refreshed skill set
+- **AND** reload diagnostics SHALL be observable

--- a/openspec/changes/integrate-skill-runtime/tasks.md
+++ b/openspec/changes/integrate-skill-runtime/tasks.md
@@ -1,0 +1,46 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `skills` spec delta，定义 runtime 加载、always 注入、matched 注入和 reload 语义。
+- [ ] 1.2 更新 `configuration` spec delta，定义 skill roots 配置。
+- [ ] 1.3 更新 `cli` spec delta，定义 `/skills` 和 `/skills reload`。
+- [ ] 1.4 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.5 明确本 change 依赖 `add-slash-command-framework`，不包含 skill authoring、marketplace 或 semantic search。
+- [ ] 1.6 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，逐项确认 skill roots 默认值、注入位置、匹配算法、trace 可观测性、错误诊断和测试策略。
+- [ ] 1.7 维护 `## Impact Analysis`，列出影响、不影响和待确认影响面；开发前把待确认项清理为明确结论或阻塞项。
+- [ ] 1.8 维护 `## Reference Implementation Research`；开发前补充更具体的参考实现文件和设计影响。
+- [ ] 1.9 在 `design.md` 的 `## Pre-Implementation Review` 记录已解决问题、备选方案、否决方案、最终确认和剩余风险。
+
+## 2. 测试
+
+- [ ] 2.1 新增 skill runtime 测试，覆盖多 root 加载、无效 skill 诊断和重复名称处理。
+- [ ] 2.2 新增 always skill 注入测试。
+- [ ] 2.3 新增 matched skill 当前 run 注入测试。
+- [ ] 2.4 新增配置解析测试，覆盖 `skills.roots` 默认值、路径展开和非法配置 fail fast。
+- [ ] 2.5 新增 CLI `/skills` 和 `/skills reload` 测试。
+- [ ] 2.6 新增 trace/debug 或运行事件测试，覆盖 loaded/matched skill 可观测性。
+
+## 3. 实现
+
+- [ ] 3.1 扩展配置模型，增加 skill roots。
+- [ ] 3.2 增强 SkillLoader 或新增 skill runtime/cache，记录来源和加载诊断。
+- [ ] 3.3 将 always skill 注入默认系统提示。
+- [ ] 3.4 将 matched skill 注入当前 run 上下文，并避免永久污染 memory。
+- [ ] 3.5 接入 slash command registry，实现 `/skills` 和 `/skills reload`。
+- [ ] 3.6 更新必要文档。
+
+## 4. 验证
+
+- [ ] 4.1 运行 skills 相关测试。
+- [ ] 4.2 运行配置和 CLI 相关测试。
+- [ ] 4.3 运行全量测试。
+- [ ] 4.4 运行 OpenSpec strict validate。
+- [ ] 4.5 运行项目 OpenSpec artifact checker。
+- [ ] 4.6 如实现触碰 AgentLoop 核心运行路径，跑通至少一个 benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前，将本 change 归档到 `openspec/changes/archive/YYYY-MM-DD-integrate-skill-runtime/`。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change，并同步并行开发批次。
+- [ ] 5.3 确认 Impact Analysis 不再残留未解释的 `unknown`、`TBD` 或 `待确认`。
+- [ ] 5.4 确认 Reference Implementation Research 已记录最终调研状态、发现和设计影响，且没有把本地参考仓库路径写成项目依赖。
+- [ ] 5.5 运行 `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict` 和 `uv run python scripts/check_openspec_artifacts.py`。


### PR DESCRIPTION
## Summary

- 新增 `add-slash-command-framework` change，规划 slash command registry 与 `/help`、`/exit`、`/status`、`/mode`、`/clear`、`/compact`
- 新增 `integrate-skill-runtime` change，规划 skill roots、runtime 注入、`/skills` 与 `/skills reload`
- 更新 OpenSpec backlog，把基本操作面、skills、权限模型、MCP、TUI、browser 排成新的实现顺序

## Verification

- `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict`
- `uv run python scripts/check_openspec_artifacts.py`
- `git diff --check`