### PR TITLE
新增共享测试 LLM harness change

### DIFF
--- a/docs/openspec-change-backlog.md
+++ b/docs/openspec-change-backlog.md
@@ -30,9 +30,10 @@
 
 - `add-swebench-docker-harness`：已合入，后续 benchmark 相关 change 可以直接复用 Docker preflight、`status + reason` 和 SWE-bench harness 路径。
 
-### 第三批：Coding Agent 基本操作面
+### 第三批：Coding Agent 基本操作面和入口回归
 
 - `integrate-skill-runtime`：依赖已完成的 slash command framework，把已有 SkillLoader 接入配置、运行时上下文和 `/skills` 可观测入口。
+- `add-shared-test-llm-harness`：在 skills 后补齐共享 fake/real LLM 入口回归基础设施，供 CLI、Web 和未来 TUI smoke 复用。
 
 ### 第四批：工具权限模型前置
 
@@ -69,7 +70,27 @@
 - `/skills` 和 `/skills reload`。
 - 加载诊断和可观测记录。
 
-### 2. `refine-tool-permission-model`
+### 2. `add-shared-test-llm-harness`
+
+状态：未实现。
+
+批次：第三批，建议在 `integrate-skill-runtime` 之后、工具权限模型和 TUI/MCP/browser 实现前推进。
+
+建议顺序原因：
+
+- 当前 CLI、Web 和浏览器测试已经有 fake/mock/real API 路径，但 fake LLM 逻辑散落，CLI 还主要通过 `FakeAgent` 覆盖 adapter 行为。
+- 共享 fake/real LLM harness 可以让 CLI、Web 和未来 TUI 用真实 AgentLoop 做稳定入口 smoke，避免后续入口能力各自维护私有 fake runtime。
+- 在 MCP、TUI 和 browser 能力前补齐这层回归，可以降低后续外部工具、运行事件和 UI 控制面变更的回归风险。
+
+主要交付：
+
+- 共享 `ScriptedLLM` 或等价测试 harness。
+- CLI 真实 `build_agent` + fake LLM runtime smoke。
+- Web server/WebSocket 复用共享 harness。
+- deterministic Playwright fake LLM browser smoke。
+- real LLM smoke opt-in 策略和测试指南。
+
+### 3. `refine-tool-permission-model`
 
 状态：未实现。
 
@@ -89,7 +110,7 @@
 - legacy `read_only` / `dangerous` 兼容路径。
 - 配置和测试迁移策略。
 
-### 3. `add-mcp-tool-adapter`
+### 4. `add-mcp-tool-adapter`
 
 状态：未实现。
 
@@ -107,7 +128,7 @@
 - MCP schema 映射为 ToolRegistry schema。
 - MCP tool 执行、错误、超时和权限元数据。
 
-### 4. `add-minimal-tui-runtime-view`
+### 5. `add-minimal-tui-runtime-view`
 
 状态：未实现。
 
@@ -125,7 +146,7 @@
 - 对话、工具调用、planning state、最终回复、diff/test 摘要和 trace 路径展示。
 - 非交互环境 graceful failure 或降级。
 
-### 5. `add-browser-use-safety-foundation`
+### 6. `add-browser-use-safety-foundation`
 
 状态：未实现。
 

--- a/openspec/changes/add-shared-test-llm-harness/design.md
+++ b/openspec/changes/add-shared-test-llm-harness/design.md
@@ -1,0 +1,122 @@
+## Context
+
+当前测试分层已经覆盖 AgentLoop 单元/集成、CLI adapter、Web server/session 和可选真实 API 浏览器 E2E，但 fake LLM 逻辑散落在多个测试文件中。CLI 入口测试多数直接替换整个 agent，Web 入口测试有私有 `MockLLM`，浏览器测试默认依赖真实 LLM。
+
+这导致一个风险：入口层看起来有测试，但它们证明的是各自局部 adapter 行为，不能稳定证明 CLI、Web 和未来 TUI 都通过同一套 AgentLoop、ToolRegistry、slash command、streaming、mode 和 tool display 语义。
+
+## Goals / Non-Goals
+
+Goals:
+
+- 抽象共享测试 LLM harness，供 CLI、Web、未来 TUI 的入口 smoke 复用。
+- 默认使用 deterministic fake LLM，覆盖真实 AgentLoop 路径。
+- 保留 opt-in real LLM profile，便于人工或夜间验证。
+- 支持普通回复、streaming、tool call、错误路径和调用记录。
+- 让 Playwright browser smoke 不再依赖真实 API。
+
+Non-Goals:
+
+- 不把 fake LLM 做成生产 provider。
+- 不替换所有已有小粒度 adapter 测试。
+- 不在本 change 实现 TUI。
+- 不把真实 API smoke 加入默认 CI。
+- 不解决所有 UI 视觉回归，只先覆盖基本功能 smoke。
+
+## Decisions
+
+### Decision 1: 共享 harness 实现 LLM protocol
+
+新增测试辅助模块，例如 `tests/support/llm_harness.py`。核心对象命名可为 `ScriptedLLM`，实现现有 `LLM` protocol，并暴露 `model` 字段，便于 CLI/Web `/status` 和调试输出复用。
+
+理由：只替换 LLM，可以保留真实 AgentLoop、ToolRegistry、Memory、hooks、runtime event 和入口输出逻辑。
+
+### Decision 2: 脚本化响应是默认 fake 模型
+
+`ScriptedLLM` 接收一组 response step。step 至少覆盖：
+
+- 普通 `LLMResponse(content=...)`
+- streaming delta 和最终 `streamed` 完成态
+- tool call response
+- provider-like error
+- 调用记录和断言辅助
+
+理由：入口回归需要可预测，而不是依赖模型自然语言质量。
+
+### Decision 3: CLI smoke 不再 fake 整个 agent
+
+新增 CLI runtime smoke 时，允许 monkeypatch `build_llm` 或注入 LLM factory，但不 monkeypatch `build_agent` 为 `FakeAgent`。已有 `FakeAgent` adapter 测试可以保留，用于快速覆盖 CLI 命令解析和输出边界。
+
+理由：`FakeAgent` 测不到 AgentLoop 与 CLI 之间的真实事件、工具和消息协议。
+
+### Decision 4: Web browser smoke 使用 fake LLM app/server
+
+新增 Playwright smoke 应启动或挂载使用共享 harness 的 Web app，覆盖页面加载、slash suggestions、命令执行、mode 切换、消息展示和基本响应。不要求 API key，也不依赖真实模型输出。
+
+理由：浏览器回归应该默认稳定；真实 API 浏览器 E2E 继续作为可选验证。
+
+### Decision 5: real LLM profile 复用 smoke 入口，不进入默认 CI
+
+harness 可以提供 real provider adapter 或 fixture profile，让同一类 smoke 在显式 flag/env 下切换到真实 LLM。默认 CI 只运行 fake LLM。
+
+理由：真实 API 适合发现 provider 集成问题，但不适合作为基础门禁。
+
+### Decision 6: TUI 实现前必须接入同一 harness
+
+未来 TUI change 进入实现时，应使用本 harness 做至少一个 fake LLM 入口 smoke，覆盖 TUI 输入事件、runtime event 消费和屏幕状态。
+
+理由：TUI 不能另起一套 fake runtime，否则 CLI/Web/TUI 行为会漂移。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - 本 change 是测试基础设施能力，不只是 Web Playwright 测试。
+  - fake LLM 应作为共享驱动层，而不是每个入口 fake agent。
+  - CLI、Web 和未来 TUI 都应能接入同一 harness。
+  - 真实 LLM smoke 需要保留，但必须是 opt-in。
+- Options considered:
+  - 每个入口继续维护自己的 mock。
+  - 共享 fake AgentLoop。
+  - 共享 fake LLM 并保留真实 AgentLoop。
+  - 将真实 API 浏览器 E2E 作为默认回归。
+- Rejected alternatives:
+  - 每个入口私有 mock。原因：会继续产生测试语义漂移。
+  - 共享 fake AgentLoop。原因：无法证明入口和真实 runtime 的集成。
+  - 默认真实 API E2E。原因：慢、依赖外部网络/API key、模型输出不稳定。
+- Final confirmations:
+  - 本 PR 只创建 change，不开始实现。
+  - 开发前必须使用 `grill-with-docs` 或等价设计追问确认 harness API、fixture 注入方式、Playwright server 生命周期、real LLM flag 和 CI 策略。
+  - 开发前必须补充 Reference Implementation Research 的具体参考仓库发现。
+- Remaining risks:
+  - 如果 harness API 太宽，会变成另一套 provider 抽象。
+  - 如果 Playwright 环境依赖处理不好，默认回归可能 flaky。
+  - 如果 CLI 只能通过 monkeypatch `build_llm` 接入，后续可能需要更清晰的 factory seam。
+
+## Risks / Trade-offs
+
+- [Risk] 测试辅助模块被生产代码依赖。Mitigation: 放在 `tests/support/` 或等价测试目录，生产代码不 import。
+- [Risk] fake LLM 过度模拟 provider 细节。Mitigation: 只实现 `LLM` protocol 和入口 smoke 所需行为，provider serialization 仍由 provider 单元测试覆盖。
+- [Risk] Browser smoke 引入环境不稳定。Mitigation: fake LLM browser smoke 与 real API E2E 分离；CI 是否安装 browser 由后续实现阶段确认。
+- [Risk] CLI 注入点不清晰。Mitigation: 优先 monkeypatch `build_llm`，如不够再小步引入可测试的 LLM factory，不改用户可见行为。
+
+## Testing Strategy
+
+- Harness 单元测试：
+  - 普通文本 response。
+  - streaming delta 和 complete。
+  - tool call response。
+  - error response。
+  - 调用记录、messages/tools/model 断言。
+- CLI runtime smoke：
+  - `CliRunner -> cli.main -> build_agent -> AgentLoop -> ScriptedLLM -> CLI output`。
+  - 覆盖普通回复、streaming 去重、tool call 摘要、slash command 不触发 LLM。
+- Web runtime smoke：
+  - `create_app(ScriptedLLM)` 通过 TestClient/WebSocket 覆盖 session、run id、mode、streaming、command result。
+- Web browser smoke：
+  - Playwright 打开 fake LLM Web UI。
+  - 覆盖页面加载、slash suggestions 过滤、`/status`、`/clear`、mode 切换和普通回复展示。
+- TUI 预留：
+  - TUI change 实现时必须新增至少一个 fake LLM entrance smoke。
+- 验证：
+  - 运行相关 CLI/Web/harness 测试。
+  - 如实现涉及 AgentLoop 或 tool path，运行至少一个 benchmark smoke。
+  - 运行全量测试、OpenSpec strict validate 和 artifact checker。

--- a/openspec/changes/add-shared-test-llm-harness/proposal.md
+++ b/openspec/changes/add-shared-test-llm-harness/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+当前仓库已经有多层 fake/mock 测试，但入口形态之间还没有统一的测试 LLM 驱动层：
+
+- CLI 测试主要 monkeypatch `build_agent` 为 `FakeAgent`，能覆盖 CLI 参数、输出和 slash command 路由，但没有完整经过 `CLI -> AgentLoop -> fake LLM -> 工具/事件 -> CLI 输出`。
+- Web server/session 测试已有 `MockLLM`，能通过 FastAPI/WebSocket 和 AgentLoop 跑 fake LLM，但这个 mock 是 Web 测试私有实现。
+- Playwright 浏览器测试当前偏真实 API E2E，依赖 API key 和模型行为，不适合作为默认基础回归。
+- 未来 TUI 也需要同样的入口 smoke；如果没有共享 harness，TUI 很容易重新发明一套 fake runtime。
+
+本 change 目标是抽象共享的 fake/real LLM test harness，让 CLI、Web、未来 TUI 都能接入真实入口和 AgentLoop 逻辑做稳定回归，同时保留可选真实 LLM smoke。
+
+## Change Type
+
+- primary: feature
+- secondary: [process]
+
+## What Changes
+
+- 新增共享测试 LLM harness，提供 `ScriptedLLM` 或等价实现，兼容现有 `LLM` protocol。
+- harness SHALL 支持脚本化普通回复、streaming delta、tool call、错误返回和调用记录。
+- CLI smoke SHALL 能只替换 LLM，不替换整个 AgentLoop，从而覆盖真实 `build_agent`、ToolRegistry、runtime event 和 CLI 输出路径。
+- Web server/browser smoke SHALL 复用同一 harness，避免 Web 私有 `MockLLM` 继续扩散。
+- 未来 TUI 实现时 SHALL 使用同一 harness 做入口 smoke。
+- harness SHALL 允许切换到真实 provider 作为 opt-in smoke；真实 LLM 不进入默认 CI 门禁。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: 增加共享测试 LLM harness 对 AgentLoop fake/real smoke 的约束。
+- `cli`: 要求 CLI 入口回归能通过真实 AgentLoop 和共享 fake LLM 运行。
+- `web-ui`: 要求 Web server/browser 回归能通过共享 fake LLM 运行，不依赖真实 API。
+- `tui`: 为未来 TUI 入口 smoke 预留同一 harness 约束。
+
+## Impact Analysis
+
+- 影响代码：
+  - 可能新增 `tests/support/llm_harness.py` 或等价测试辅助模块。
+  - 可能调整 `tests/test_cli.py`，新增 CLI runtime smoke。
+  - 可能调整 `tests/web_tests/`，复用共享 harness，并新增 deterministic Playwright smoke。
+  - 未来 `tui/` 或 TUI 测试应复用该 harness。
+- 影响测试：
+  - CLI fake LLM runtime smoke。
+  - Web FastAPI/WebSocket fake LLM smoke。
+  - Web Playwright fake LLM browser smoke。
+  - harness 自身单元测试，覆盖文本、streaming、tool call、错误和调用记录。
+  - 可选 real API smoke 继续通过显式 flag 或环境变量开启。
+- 影响文档：
+  - `docs/testing-guide.md`
+  - 相关 OpenSpec current specs：`agent-runtime`、`cli`、`web-ui`、`tui`
+  - 必要时更新 `docs/development-guide.md`
+- 依赖：
+  - 依赖现有 `LLM` protocol、AgentLoop、CLI build path、Web SessionManager。
+  - Web browser smoke 依赖 Playwright 运行环境；不要求真实 API key。
+- 不影响：
+  - 不改变生产 LLM provider 行为。
+  - 不把 fake LLM 暴露为用户可选 provider。
+  - 不改变 benchmark fake runner 语义。
+  - 不实现 TUI 本体。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 入口形态回归测试是 coding agent 质量门禁的一部分，应参考其他 coding agent 如何组织 fake provider、入口 smoke、browser/TUI 回归和真实模型可选验证。
+- research questions:
+  - 参考项目如何把 fake LLM/provider 接入 CLI、Web、TUI 或 app-server 测试？
+  - fake provider 是否使用脚本化响应、fixture server、record/replay，还是直接 fake agent runtime？
+  - streaming、tool call 和错误路径在入口 smoke 中如何建模？
+  - 真实 LLM smoke 如何与默认 CI 隔离？
+  - browser/TUI 回归如何避免模型输出不确定性导致 flaky？
+- findings:
+  - 当前仓库已有足够内部证据说明需要共享 harness：CLI 使用 `FakeAgent`，Web 使用私有 `MockLLM`，浏览器测试依赖 `--run-real-api`。
+  - 本 PR 只创建 change，不进入实现；开发前必须基于 `.dev/reference-repos.txt` 中可用参考仓库补充具体参考实现发现。
+  - 如果本地参考仓库不可用，开发前需要记录不可用原因，并以当前仓库测试结构和公开文档作为替代依据。
+- design impact:
+  - 初始方案坚持 fake LLM 层复用，而不是每个入口 fake 整个 AgentLoop。
+  - 真实 LLM smoke 保持 opt-in，避免默认 CI 被外部 API、网络和模型随机性污染。
+  - Playwright browser smoke 应走 fake LLM app/server，真实 API 浏览器 E2E 保留为人工或夜间验证。

--- a/openspec/changes/add-shared-test-llm-harness/specs/agent-runtime/spec.md
+++ b/openspec/changes/add-shared-test-llm-harness/specs/agent-runtime/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Agent runtime 入口回归使用共享测试 LLM harness
+
+项目 SHALL 提供共享测试 LLM harness，用于在测试中以确定性 fake LLM 或显式 opt-in real LLM 驱动真实 AgentLoop 和入口层 smoke。默认 fake LLM SHALL 兼容现有 `LLM` protocol，并支持普通文本、streaming、tool call、错误路径和调用记录。
+
+#### Scenario: Fake LLM 驱动真实 AgentLoop
+
+- **GIVEN** 测试使用共享 fake LLM harness
+- **WHEN** 入口 smoke 构造 AgentLoop
+- **THEN** 系统 SHALL 使用真实 AgentLoop、ToolRegistry、Memory 和 runtime event 路径
+- **AND** SHALL 只替换 LLM provider 行为
+
+#### Scenario: Harness 记录 LLM 调用
+
+- **GIVEN** AgentLoop 通过共享 fake LLM harness 执行一次 run
+- **WHEN** 测试检查 harness 状态
+- **THEN** harness SHALL 暴露调用次数、messages、tools 和 model 等断言信息
+
+#### Scenario: Real LLM smoke 显式开启
+
+- **GIVEN** 测试 harness 支持真实 provider profile
+- **WHEN** 未显式传入 real API flag 或对应环境变量
+- **THEN** 默认回归 SHALL 使用 fake LLM
+- **AND** SHALL NOT 要求真实 API key、外部网络或真实模型输出

--- a/openspec/changes/add-shared-test-llm-harness/specs/cli/spec.md
+++ b/openspec/changes/add-shared-test-llm-harness/specs/cli/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: CLI 入口回归复用共享测试 LLM harness
+
+CLI 测试 SHALL 覆盖通过真实 `build_agent` 和 AgentLoop 执行的 fake LLM runtime smoke。已有 adapter 级 `FakeAgent` 测试 MAY 保留，但不得作为 CLI 入口逻辑的唯一回归形态。
+
+#### Scenario: CLI 单轮 fake LLM smoke
+
+- **GIVEN** CLI 测试注入共享 fake LLM harness
+- **WHEN** 执行 CLI 单轮 prompt
+- **THEN** CLI SHALL 通过真实 `build_agent` 构造 AgentLoop
+- **AND** 输出 fake LLM 返回的 assistant 内容
+- **AND** 测试 SHALL 能断言 fake LLM 收到的用户消息
+
+#### Scenario: CLI streaming fake LLM smoke
+
+- **GIVEN** fake LLM 脚本返回 streaming delta 和 streamed completion
+- **WHEN** CLI 执行单轮 prompt
+- **THEN** CLI SHALL 实时输出 delta
+- **AND** SHALL NOT 重复打印最终完整文本
+
+#### Scenario: CLI control command 不触发 LLM
+
+- **GIVEN** CLI 交互模式使用共享 fake LLM harness
+- **WHEN** 用户输入 `/status`、`/clear` 或未知独立 slash command
+- **THEN** CLI SHALL 按控制面输入处理该命令
+- **AND** fake LLM 调用次数 SHALL 保持不变

--- a/openspec/changes/add-shared-test-llm-harness/specs/tui/spec.md
+++ b/openspec/changes/add-shared-test-llm-harness/specs/tui/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: 未来 TUI 回归复用共享测试 LLM harness
+
+未来 TUI 实现 SHALL 使用共享测试 LLM harness 做入口 smoke，覆盖 TUI 输入、AgentLoop runtime event 消费和屏幕状态展示。TUI SHALL NOT 定义与 CLI/Web 不兼容的 fake runtime。
+
+#### Scenario: TUI fake LLM smoke
+
+- **GIVEN** 未来 TUI 已实现
+- **WHEN** TUI 测试注入共享 fake LLM harness 并发送用户输入
+- **THEN** TUI SHALL 通过真实 AgentLoop 运行
+- **AND** 屏幕状态 SHALL 展示 fake assistant 回复、session id 和 run id
+
+#### Scenario: TUI 不使用私有 fake runtime
+
+- **GIVEN** TUI change 准备进入实现
+- **WHEN** 设计测试策略
+- **THEN** 测试 SHALL 复用共享 fake LLM harness
+- **AND** 不得用只服务于 TUI 的私有 fake AgentLoop 替代入口 smoke

--- a/openspec/changes/add-shared-test-llm-harness/specs/web-ui/spec.md
+++ b/openspec/changes/add-shared-test-llm-harness/specs/web-ui/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Web UI 回归复用共享测试 LLM harness
+
+Web server、WebSocket 和浏览器回归 SHALL 能通过共享 fake LLM harness 运行，不依赖真实 API key 或模型输出。真实 API 浏览器 E2E MAY 保留为显式 opt-in 验证。
+
+#### Scenario: WebSocket fake LLM smoke
+
+- **GIVEN** Web app 使用共享 fake LLM harness 创建
+- **WHEN** 浏览器或测试客户端通过 WebSocket 发送聊天消息
+- **THEN** Web session SHALL 通过真实 SessionManager 和 AgentLoop 运行
+- **AND** WebSocket SHALL 返回 run event 和 fake assistant 回复
+
+#### Scenario: Playwright fake LLM browser smoke
+
+- **GIVEN** Playwright 打开使用共享 fake LLM harness 的 Web UI
+- **WHEN** 用户发送普通消息
+- **THEN** 页面 SHALL 展示 fake assistant 回复
+- **AND** 测试 SHALL 不需要真实 API key
+
+#### Scenario: Browser smoke 覆盖控制面基础交互
+
+- **GIVEN** Playwright 打开 Web Chat
+- **WHEN** 用户输入 slash command 前缀、执行 `/status`、执行 `/clear` 或切换 mode
+- **THEN** 页面 SHALL 展示对应 suggestions、command result、消息清理和 mode 变化
+- **AND** 这些控制面操作 SHALL NOT 启动普通 Agent run

--- a/openspec/changes/add-shared-test-llm-harness/tasks.md
+++ b/openspec/changes/add-shared-test-llm-harness/tasks.md
@@ -1,0 +1,50 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `agent-runtime` spec delta，定义共享测试 LLM harness 的 fake/real smoke 语义。
+- [ ] 1.2 更新 `cli` spec delta，定义 CLI fake LLM runtime smoke 约束。
+- [ ] 1.3 更新 `web-ui` spec delta，定义 Web server/browser fake LLM smoke 约束。
+- [ ] 1.4 更新 `tui` spec delta，定义未来 TUI 必须复用共享 harness。
+- [ ] 1.5 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.6 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，逐项确认 harness API、fixture 注入方式、Playwright server 生命周期、real LLM flag、CI 策略和文档影响。
+- [ ] 1.7 维护 `## Impact Analysis`，列出影响、不影响和待确认影响面；开发前把待确认项清理为明确结论或阻塞项。
+- [ ] 1.8 维护 `## Reference Implementation Research`；开发前基于 `.dev/reference-repos.txt` 中可用参考仓库补充具体实现发现和设计影响。
+- [ ] 1.9 在 `design.md` 的 `## Pre-Implementation Review` 记录已解决问题、备选方案、否决方案、最终确认和剩余风险。
+
+## 2. 测试
+
+- [ ] 2.1 新增共享 `ScriptedLLM` 或等价 harness 单元测试，覆盖普通回复、streaming、tool call、错误和调用记录。
+- [ ] 2.2 新增 CLI runtime smoke，覆盖真实 `build_agent` + fake LLM 的单轮输出。
+- [ ] 2.3 新增 CLI runtime smoke，覆盖 streaming 去重和 tool call 摘要。
+- [ ] 2.4 新增 Web server/session smoke 复用共享 harness，替换或收敛私有 `MockLLM`。
+- [ ] 2.5 新增 deterministic Playwright browser smoke，覆盖页面加载、slash suggestions、`/status`、`/clear`、mode 切换和普通回复展示。
+- [ ] 2.6 保留 real API smoke 为显式 opt-in，并覆盖 fake/real profile 切换配置或 pytest flag。
+- [ ] 2.7 为未来 TUI change 增加测试指南约束，说明 TUI 必须接入共享 harness。
+
+## 3. 实现
+
+- [ ] 3.1 新增 `tests/support/llm_harness.py` 或等价测试辅助模块。
+- [ ] 3.2 实现 `ScriptedLLM` response script、调用记录和断言辅助。
+- [ ] 3.3 提供 CLI 测试注入 helper，优先只替换 LLM，不替换 AgentLoop。
+- [ ] 3.4 提供 Web app/server 测试 helper，复用同一 harness。
+- [ ] 3.5 将 Web 私有 `MockLLM` 逐步收敛到共享 harness，保留必要的局部轻量 fixture。
+- [ ] 3.6 新增或调整 Playwright fixture，使 browser smoke 默认不依赖真实 API。
+- [ ] 3.7 更新必要文档。
+
+## 4. 验证
+
+- [ ] 4.1 运行 harness 单元测试。
+- [ ] 4.2 运行 CLI 相关测试。
+- [ ] 4.3 运行 Web session/server 测试。
+- [ ] 4.4 运行 Playwright fake LLM browser smoke；如当前环境缺少浏览器依赖，记录明确原因和替代验证。
+- [ ] 4.5 运行全量测试。
+- [ ] 4.6 运行 OpenSpec strict validate。
+- [ ] 4.7 运行项目 OpenSpec artifact checker。
+- [ ] 4.8 如实现触碰 AgentLoop、ToolRegistry 或工具协议，跑通至少一个 benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前，将本 change 归档到 `openspec/changes/archive/YYYY-MM-DD-add-shared-test-llm-harness/`。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change，并同步并行开发批次。
+- [ ] 5.3 确认 Impact Analysis 不再残留未解释的 `unknown`、`TBD` 或 `待确认`。
+- [ ] 5.4 确认 Reference Implementation Research 已记录最终调研状态、发现和设计影响，且没有把本地参考仓库路径写成项目依赖。
+- [ ] 5.5 运行 `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict` 和 `uv run python scripts/check_openspec_artifacts.py`。


### PR DESCRIPTION
## 概要

- 新增 OpenSpec change: `add-shared-test-llm-harness`
- 定义共享 fake/real LLM test harness，用于 CLI、Web 和未来 TUI 的入口形态回归
- 为 agent-runtime、cli、web-ui、tui 增加 spec delta
- 更新 OpenSpec change backlog，把该 change 排入第三批入口回归基础设施

## 说明

本 PR 只创建 change，不包含实现代码。后续开始实现前仍需按项目规则使用 `grill-with-docs` 或等价设计追问，并补齐参考实现调研。

## 验证

- `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict`
- `uv run python scripts/check_openspec_artifacts.py`