### PR TITLE
新增 6 个基础能力补全 OpenSpec change 规划文档

### DIFF
--- a/docs/openspec-change-backlog.md
+++ b/docs/openspec-change-backlog.md
@@ -44,13 +44,127 @@
 - `add-mcp-tool-adapter`：已合入并归档。
 - `add-minimal-tui-runtime-view`：建议在 skills、工具权限模型、planning state、streaming、runtime mode switching、工具结果 display policy 和已完成的 slash command framework 稳定后做，复用统一运行事件和 mode transition。
 
-### 第六批：高风险 browser 能力
+### 第六批：基础能力补全
+
+基于与其他 coding agent（Claude Code、Codex、Cursor、Aider 等）的系统性对比，以下 6 个 change 覆盖了 Asterwynd 当前必备基础能力的核心缺口。第一批（1/3/4）可并行推进，第二批 2 等 1 合入后开始（共享 AgentLoop 改动面），第三批 5/6 可并行。
+
+- `improve-agent-execution-foundation`：Agent 执行可靠性——todo 任务追踪 + 工具错误恢复重试。
+- `add-parallel-tool-execution`：AgentLoop 并行工具执行——独立只读调用并发化。
+- `add-persistent-cross-session-memory`：跨 session 持久记忆——user/feedback/project/reference 四类，与 Claude Code 格式兼容。
+- `add-semantic-code-search`：语义代码搜索——embedding 索引 + SearchSimilar 工具。
+- `add-multimodal-input-support`：图片/多模态输入——Message 协议扩展 + Read 工具图片支持。
+- `add-background-task-execution-and-session-persistence`：后台任务执行 + 会话保存/恢复。
+
+### 第七批：高风险 browser 能力
 
 - `add-browser-use-safety-foundation`：风险高于 MCP，应在配置、mode policy、workspace safety 和工具权限模型稳定后做。
 
 ## 未实现队列
 
-### 1. `add-minimal-tui-runtime-view`
+### 1. `improve-agent-execution-foundation`
+
+状态：未实现。
+
+批次：第六批，第一批可并行推进。
+
+建议顺序原因：
+
+- Todo 追踪和错误重试都是小改动、低风险、高回报。
+- 不依赖其他 change，可独立开发合入。
+
+主要交付：
+
+- `TodoWrite` 工具（create/update/list）。
+- AgentLoop 接入 RetryHook，基于错误类型分类的重试策略。
+- build mode 系统消息注入 todo 状态；TUI/Web 可选 todo 面板。
+
+### 2. `add-parallel-tool-execution`
+
+状态：未实现。
+
+批次：第六批第二批，建议等 `improve-agent-execution-foundation` 合入后再开始（共享 AgentLoop 改动面）。
+
+建议顺序原因：
+
+- AgentLoop 核心重构，架构风险最高。
+- 与 Change 1 共享 `loop.py` 改动面，错开合入避免冲突。
+
+主要交付：
+
+- Tool 基类 `parallelizable` 属性。
+- AgentLoop 分组并行执行（连续只读 tool calls 同组并发）。
+- 并行组审批退化策略；错误隔离。
+
+### 3. `add-persistent-cross-session-memory`
+
+状态：未实现。
+
+批次：第六批第一批，可并行推进。
+
+建议顺序原因：
+
+- 自包含的 memory 模块扩展，只新增文件和工具，不改动核心路径。
+- 与 Claude Code 格式兼容，方便后续互操作。
+
+主要交付：
+
+- `PersistentMemory` 类，管理四类记忆文件。
+- `SaveMemory` / `RecallMemory` 工具。
+- AgentLoop 系统消息注入持久记忆上下文。
+
+### 4. `add-semantic-code-search`
+
+状态：未实现。
+
+批次：第六批第一批，可并行推进。
+
+建议顺序原因：
+
+- 完全独立的 code_intelligence 模块扩展。
+- 不影响 AgentLoop 核心路径。
+
+主要交付：
+
+- `agent/code_intelligence/embeddings.py` — embedding 模型加载和编码。
+- `agent/code_intelligence/index.py` — sqlite-vec 向量索引。
+- `SearchSimilar` 语义搜索工具。
+
+### 5. `add-multimodal-input-support`
+
+状态：未实现。
+
+批次：第六批第三批，改动面最大（Message 协议 + 所有 provider adapter），建议等第一批合入后再开始。
+
+建议顺序原因：
+
+- 触及整个消息传递链（Message → LLM adapter → compact → trace → subagent）。
+- 需要等 AgentLoop 改动（Change 1/2）稳定后再叠加 Message 协议扩展。
+
+主要交付：
+
+- `Message.content` 扩展为 `str | list[ContentBlock]`。
+- `ToolResult.content_blocks` 新增字段。
+- Read 工具图片识别 + base64 编码。
+- OpenAI/Anthropic adapter 多模态格式转换。
+
+### 6. `add-background-task-execution-and-session-persistence`
+
+状态：未实现。
+
+批次：第六批第三批，可并行推进。
+
+建议顺序原因：
+
+- Bash 后台执行和 session 持久化都不改变已有核心路径语义。
+- 新增组件（BackgroundTaskManager、SessionStore）不与其他 change 冲突。
+
+主要交付：
+
+- Bash `run_in_background` 参数 + BackgroundTaskManager。
+- `TaskOutput` / `TaskStop` 工具。
+- SessionStore 序列化/恢复 + CLI `--resume`。
+
+### 7. `add-minimal-tui-runtime-view`
 
 状态：未实现。
 
@@ -68,7 +182,7 @@
 - 对话、工具调用、planning state、最终回复、diff/test 摘要和 trace 路径展示。
 - 非交互环境 graceful failure 或降级。
 
-### 2. `add-browser-use-safety-foundation`
+### 8. `add-browser-use-safety-foundation`
 
 状态：未实现。
 

--- a/openspec/changes/add-background-task-execution-and-session-persistence/design.md
+++ b/openspec/changes/add-background-task-execution-and-session-persistence/design.md
@@ -1,0 +1,190 @@
+## Context
+
+Bash 工具同步阻塞的问题在 benchmark 中已暴露：agent 跑完整测试套件时阻塞等待 2 分钟，期间无法做任何有用工作。同时，Web UI 和 CLI 交互模式都面临 session 断开丢失上下文的问题。
+
+两个子能力的技术方案不同但共享"跨调用状态管理"的设计约束，合入同一 change 可以减少架构碎片化。
+
+## Decisions
+
+### Part A: 后台任务执行
+
+#### A.1 Bash 扩展
+
+```python
+class BashInput:
+    command: str
+    run_in_background: bool = False
+    timeout: int | None = None
+```
+
+当 `run_in_background=True`：
+- `Bash.execute()` 启动子进程（`asyncio.create_subprocess_shell`）。
+- 注册到 `BackgroundTaskManager`。
+- 返回 `"Task started: <task_id>. Use TaskOutput to check status."`。
+- `timeout` 参数仍生效：后台任务超时后标记为 `timeout` 状态。
+
+#### A.2 BackgroundTaskManager
+
+```
+task_id -> {
+    process: asyncio.subprocess.Process,
+    command: str,
+    started_at: float,
+    status: running | completed | timeout | failed,
+    exit_code: int | None,
+    stdout: str,
+    stderr: str,
+}
+```
+
+关键行为：
+- AgentLoop 每次迭代开始时调用 `manager.check_completed()` → 收集所有已完成的后台任务。
+- 每个已完成的后台任务作为一条 tool result 消息注入到消息列表（role=tool, name=Bash, content=结构化输出）。
+- 同个 task_id 最多报告一次（报告后从 active 列表移到历史）。
+- AgentLoop 退出时，`BackgroundTaskManager` 清理所有仍在运行的进程（SIGTERM，等 5s，SIGKILL）。
+
+#### A.3 TaskOutput / TaskStop 工具
+
+- `TaskOutput(task_id, block=True, timeout=30000)`：获取任务输出。`block=True` 时等待直到 completed/timeout/failed（非阻塞轮询，1s 间隔）。`block=False` 时立即返回当前状态。超时后返回已收集的部分输出。
+- `TaskStop(task_id)`：发送 SIGTERM，等 3s，SIGKILL。返回最终输出。
+
+两个工具的 capability：`COMMAND_EXECUTE` / `HIGH` risk（TaskStop 可终止进程）。
+
+### Part B: 会话持久化
+
+#### B.1 持久化范围
+
+持久化内容：
+```python
+@dataclass
+class SessionSnapshot:
+    session_id: str
+    created_at: str
+    updated_at: str
+    messages: list[Message]
+    mode: AgentMode
+    todos: list[TodoItem]
+    active_skills: list[str]
+    run_id: str
+    iteration: int
+    tool_call_count: int
+    edit_count: int
+```
+
+明确不持久化：
+- LLM client（需要重新初始化 API key / connection）
+- MCP server 连接（需要重新启动和发现）
+- Background tasks（后台进程在 session 保存时不杀死，但不恢复——下一 session 的 agent 无法继续检查它们）
+- WorkspacePolicy（重新从配置构建）
+
+#### B.2 存储格式
+
+```
+.asterwynd/sessions/
+  <session_id>/
+    snapshot.json    # SessionSnapshot JSON
+    messages.json    # 完整消息历史（可能很大）
+```
+
+`snapshot.json` 包含除 messages 外的所有字段，`messages.json` 是 `list[dict]`。
+
+#### B.3 保存时机
+
+1. **自动保存**：每次迭代结束后自动写入（可配置：`config.session.auto_save: bool = True`）。
+2. **手动保存**：agent 可以调用内置的 save session 行为（不是单独工具，由 `--save-on-exit` CLI 参数控制）。
+3. **退出时保存**：AgentLoop 正常结束时保存最终快照。
+
+#### B.4 恢复入口
+
+```bash
+uv run python cli.py main --resume <session_id>
+uv run python cli.py web --resume <session_id>
+```
+
+恢复流程：
+1. 加载 `snapshot.json` + `messages.json`。
+2. 重建 `AgentLoop`，注入消息历史、mode、todos、skills。
+3. 系统消息追加 `## Session Resumed\nPrevious session <session_id> ended at <timestamp>.\n`
+4. 正常进入交互循环。
+
+如果 session 文件损坏或 message 格式不兼容（例如升级后），返回明确错误而非静默失败。
+
+#### B.5 CLI 变更
+
+```
+cli.py main [--resume SESSION_ID]
+cli.py web [--resume SESSION_ID]
+cli.py session list     # 列出可恢复 session
+cli.py session rm ID    # 删除某个 session
+```
+
+### 子能力间的交互
+
+- 后台任务在 session 保存时不随 agent 状态一起序列化（后台进程的生命周期独立于 AgentLoop）。
+- 会话恢复后再启动后台任务时使用新的 BackgroundTaskManager 实例。
+- Todo 列表持久化同时由 session save 和 Change 1 的 todo 工具间接受益。
+
+## Goals / Non-Goals
+
+- 不跨机器恢复会话（不支持远程 session sync）。
+- 不支持后台任务的依赖管理（task A → task B 依赖）。
+- 不持久化 LSP server 连接状态。
+- 不持久化 embedding 索引状态。
+- `--resume` 不支持恢复部分消息（不支持 --resume-from-iteration N）。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 的 background task 如何实现？
+2. Claude Code 的 --resume 如何工作？
+3. Aider 的会话管理机制？
+
+- findings:
+
+- Claude Code 的 `Bash` 工具有 `run_in_background` 参数。后台任务启动后返回 task_id；`TaskOutput` 工具用于轮询结果。Claude Code 的后台任务在 agent 退出时会自动终止（不持久化后台进程）。
+- Claude Code 的 `--resume` 使用 `.claude/sessions/` 目录存储会话快照，恢复时注入 "继续上次对话" 的上下文提示。Resumed session 的 compaction 状态、mode 等都会恢复。
+- Aider 有 `/run` 命令支持后台执行测试和 lint 命令。没有独立的会话持久化机制。
+
+- design impact:
+
+- Background task 设计直接参考 Claude Code 的 Bash + TaskOutput 模式。
+- Session 持久化格式使用 JSON（而非 pickle），确保可读性和向前兼容。
+- 后台任务不与 session 绑定（不跨恢复），与 Claude Code 行为一致。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| Bash 工具 | 新增 run_in_background 参数 |
+| AgentLoop | 迭代开始检查已完成后台任务、迭代结束自动保存 session |
+| ToolRegistry | 新增 TaskOutput / TaskStop |
+| CLI | 新增 --resume 和 session 子命令 |
+| Workspace safety | 后台命令仍通过 allowlist/denylist 检查 |
+| 审批链路 | 后台命令在启动时走一次审批（不额外审批检查结果） |
+| MemoryManager compact | 后台任务结果作为普通 tool result 参与 compact |
+| MCP | 不影响 |
+| Benchmark | 不影响（benchmark 不持久化、不使用后台任务） |
+| TUI/Web | TUI 可选展示后台任务状态条 |
+
+
+## Risks / Trade-offs
+
+- [Risk] 后台进程可能在 AgentLoop 退出时未正确清理。Mitigation: `run()` 的 finally 块中强制 SIGTERM → SIGKILL 清理所有活跃进程。
+- [Risk] Session 恢复时消息格式不兼容（跨版本升级）。Mitigation: SessionSnapshot 包含 schema_version 字段，版本不匹配时明确报错。
+- [Risk] 自动保存 session 可能在频繁迭代时产生磁盘 I/O 压力。Mitigation: 只在有变更时写入（基于 messages hash），可配置关闭。
+
+## Testing Strategy
+
+- BackgroundTaskManager 单元测试：启动/状态/输出获取/超时终止/进程清理。
+- Bash 工具测试：run_in_background=True 返回 task_id、后台命令仍过安全门。
+- TaskOutput/TaskStop 工具测试：block/非阻塞查询、终止运行中任务。
+- SessionStore 单元测试：保存快照/恢复/损坏文件报错/不存在的 session。
+- AgentLoop 集成：后台任务完成后注入结果、退出时清理进程。
+- CLI 测试：--resume 参数、session list/rm。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/add-background-task-execution-and-session-persistence/proposal.md
+++ b/openspec/changes/add-background-task-execution-and-session-persistence/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+当前 Asterwynd 有两个"跨单次工具调用"的能力缺口：
+
+1. **无法后台执行任务**：`Bash` 工具同步阻塞，长时间命令（全量测试、npm install）占用整个 agent 迭代。Claude Code 的 `run_in_background` 参数允许 agent 让命令后台执行、稍后检查结果。
+
+2. **无法保存恢复会话**：Session 断开后全部上下文丢失。Claude Code 有 `--resume`，Codex 有会话持久化。
+
+两者共享核心概念——"跨工具调用的状态生命周期"。后台任务需要进程管理器（跨调用的进程状态），会话恢复需要序列化（跨进程的 AgentLoop 状态）。合入同一个 change 做一个统一的状态持久化抽象。
+
+## What Changes
+
+### 后台任务执行
+
+- `Bash` 工具新增 `run_in_background: bool = False` 参数。
+- 新增 `agent/background.py`：`BackgroundTaskManager`，管理后台进程的启动、状态查询和清理。
+- 新增工具：
+  - `TaskOutput(task_id: str)`：获取后台任务的 stdout/stderr 输出和状态（running/completed/timeout/failed）。
+  - `TaskStop(task_id: str)`：终止后台任务。
+- AgentLoop 在每次迭代开始前检查已完成的后台任务，将结果作为 tool result 注入消息。
+
+### 会话持久化
+
+- 新增 `agent/session.py`：`SessionStore`，负责序列化 AgentLoop 状态。
+- 持久化内容：消息历史、当前 mode、todo 列表、技能激活状态、最近的 tool call 结果。
+- CLI 新增 `--resume <session_id>` 参数，从 SessionStore 恢复会话。
+- 会话默认保存在 `.asterwynd/sessions/` 目录下。
+- 不持久化：LLM connection、未完成的后台任务、MCP server 连接。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: `Bash` 后台执行、`AgentLoop` 会话序列化/恢复。
+- `coding-tools`: `Bash` 工具扩展 `run_in_background` 参数。
+
+## Impact
+
+- 影响代码：
+  - `agent/background.py`（新增）
+  - `agent/session.py`（新增）
+  - `agent/tools/builtin/bash.py`（新增 background 参数）
+  - `agent/tools/builtin/tasks.py`（新增 TaskOutput / TaskStop）
+  - `agent/tools/factory.py`
+  - `agent/loop.py`（后台任务结果注入、session save/restore）
+  - `cli.py`（新增 --resume 参数）
+- 影响测试：
+  - `tests/agent/test_background.py`
+  - `tests/agent/test_session.py`
+  - `tests/agent/tools/test_bash.py`
+  - `tests/agent/tools/test_tasks.py`
+  - `tests/test_cli.py`
+
+## Change Type
+
+- primary: feature
+- secondary: refactor

--- a/openspec/changes/add-background-task-execution-and-session-persistence/specs/agent-runtime/spec.md
+++ b/openspec/changes/add-background-task-execution-and-session-persistence/specs/agent-runtime/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: 后台任务执行
+
+系统 SHALL 支持通过 `Bash` 工具的 `run_in_background=True` 参数启动后台命令。启动后台命令后 SHALL 返回 task_id。`BackgroundTaskManager` SHALL 维护所有活跃后台任务的状态，并在任务完成时通过 AgentLoop 自动注入结果。
+
+#### Scenario: 启动后台任务
+
+- **GIVEN** agent 调用 Bash 且 run_in_background=True
+- **WHEN** 命令为 `pytest -q tests/`
+- **THEN** 系统 SHALL 返回 `"Task started: <task_id>"`
+- **AND** 命令 SHALL 在后台异步执行
+
+#### Scenario: 后台任务完成后注入结果
+
+- **GIVEN** 有一个活跃的后台任务正在执行
+- **WHEN** 任务完成（exit_code=0）
+- **THEN** AgentLoop SHALL 在下一次迭代开始时将该任务的输出作为 tool result 注入消息
+- **AND** 该 task_id SHALL 从活跃列表移至历史
+
+#### Scenario: AgentLoop 退出时清理后台任务
+
+- **GIVEN** AgentLoop 退出时仍有一个运行中的后台任务
+- **WHEN** AgentLoop.run() 返回
+- **THEN** BackgroundTaskManager SHALL 发送 SIGTERM 给所有活跃进程
+- **AND** 等待 5 秒后发送 SIGKILL
+
+### Requirement: 会话持久化
+
+系统 SHALL 支持将会话状态序列化到 `.asterwynd/sessions/<session_id>/` 目录。持久化内容 SHALL 包含消息历史、mode、todo 列表、技能激活状态。CLI SHALL 提供 `--resume` 参数恢复会话。
+
+#### Scenario: 会话自动保存
+
+- **GIVEN** AgentLoop 在一次迭代后仍有活跃迭代
+- **AND** config.session.auto_save 为 True
+- **WHEN** 当前迭代结束
+- **THEN** 系统 SHALL 将会话快照写入 `.asterwynd/sessions/<session_id>/`
+
+#### Scenario: 会话恢复
+
+- **GIVEN** 存在一个有效的 session 快照
+- **WHEN** 用户通过 `--resume <session_id>` 启动
+- **THEN** 系统 SHALL 加载消息历史和 mode
+- **AND** 注入 `## Session Resumed` 系统消息
+- **AND** 正常进入交互循环
+
+#### Scenario: 损坏的会话文件
+
+- **GIVEN** session 文件的 JSON 格式损坏或不兼容
+- **WHEN** 用户尝试 --resume
+- **THEN** 系统 SHALL 返回明确错误而非静默失败
+
+#### Scenario: 不存在的 session
+
+- **GIVEN** session_id 对应的目录不存在
+- **WHEN** 用户尝试 --resume
+- **THEN** 系统 SHALL 返回 "Session <id> not found"
+
+### Requirement: TaskOutput 和 TaskStop 工具
+
+系统 SHALL 提供 `TaskOutput` 和 `TaskStop` 工具用于后台任务的控制。
+
+#### Scenario: 阻塞等待任务完成
+
+- **GIVEN** 后台任务 5 秒后完成
+- **WHEN** agent 调用 TaskOutput(task_id, block=True)
+- **THEN** TaskOutput SHALL 阻塞等待直到任务完成
+- **AND** 返回 exit_code、stdout、stderr
+
+#### Scenario: 非阻塞查询
+
+- **GIVEN** 后台任务仍在运行
+- **WHEN** agent 调用 TaskOutput(task_id, block=False)
+- **THEN** TaskOutput SHALL 立即返回
+- **AND** status SHALL 为 "running"
+
+#### Scenario: 终止任务
+
+- **GIVEN** 后台任务仍在运行
+- **WHEN** agent 调用 TaskStop(task_id)
+- **THEN** 进程 SHALL 被终止
+- **AND** TaskStop SHALL 返回最终输出

--- a/openspec/changes/add-background-task-execution-and-session-persistence/specs/coding-tools/spec.md
+++ b/openspec/changes/add-background-task-execution-and-session-persistence/specs/coding-tools/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Bash 支持后台执行
+
+`Bash` 工具 SHALL 新增 `run_in_background` 参数（默认 `False`）。当 `run_in_background=True` 时，Bash SHALL 异步启动子进程并立即返回 task_id。后台命令 SHALL 仍然经过 workspace safety 的 allowlist/denylist 检查。
+
+#### Scenario: 后台命令通过安全检查
+
+- **GIVEN** agent 调用 Bash 且 run_in_background=True
+- **WHEN** 命令为 `pytest -q tests/`
+- **AND** 命令通过 allowlist 检查
+- **THEN** 命令 SHALL 在后台启动
+- **AND** SHALL 返回 task_id
+
+#### Scenario: 后台命令被拒绝
+
+- **GIVEN** agent 调用 Bash 且 run_in_background=True
+- **WHEN** 命令为 `rm -rf /`（被 denylist 拒绝）
+- **THEN** 系统 SHALL 返回权限错误
+- **AND** SHALL NOT 启动任何进程
+
+#### Scenario: 前台执行保持不变
+
+- **GIVEN** agent 调用 Bash 且 run_in_background=False（默认）
+- **WHEN** 命令执行
+- **THEN** 行为 SHALL 与改动前完全一致（同步阻塞等待结果）

--- a/openspec/changes/add-background-task-execution-and-session-persistence/tasks.md
+++ b/openspec/changes/add-background-task-execution-and-session-persistence/tasks.md
@@ -1,0 +1,52 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `agent-runtime` spec delta：定义后台任务生命周期和会话持久化语义。
+- [ ] 1.2 更新 `coding-tools` spec delta：定义 Bash 后台执行行为和 TaskOutput/TaskStop 工具。
+- [ ] 1.3 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.4 维护 `## Impact Analysis`。
+- [ ] 1.5 维护 `## Reference Implementation Research`。
+
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+
+## 2. 测试
+
+- [ ] 2.1 BackgroundTaskManager 测试：启动后台进程、检查状态、获取输出。
+- [ ] 2.2 BackgroundTaskManager 测试：超时自动终止、进程清理。
+- [ ] 2.3 Bash 工具测试：run_in_background=True 返回 task_id。
+- [ ] 2.4 TaskOutput 测试：block 模式等待完成、非阻塞模式立即返回。
+- [ ] 2.5 TaskStop 测试：终止运行中的后台任务。
+- [ ] 2.6 AgentLoop 集成测试：后台任务完成后自动注入结果。
+- [ ] 2.7 SessionStore 测试：保存快照、从快照恢复、消息序列化。
+- [ ] 2.8 SessionStore 测试：损坏文件返回明确错误。
+- [ ] 2.9 AgentLoop 集成测试：恢复后继续正常迭代。
+- [ ] 2.10 CLI 测试：--resume 参数加载会话、session list/rm 子命令。
+
+## 3. 实现
+
+- [ ] 3.1 实现 `agent/background.py` — BackgroundTaskManager。
+- [ ] 3.2 实现 `agent/session.py` — SessionStore + SessionSnapshot。
+- [ ] 3.3 扩展 `agent/tools/builtin/bash.py` — run_in_background 参数。
+- [ ] 3.4 实现 `agent/tools/builtin/tasks.py` — TaskOutput / TaskStop。
+- [ ] 3.5 在 `factory.py` 注册 TaskOutput / TaskStop。
+- [ ] 3.6 AgentLoop：迭代开始时注入已完成后台任务结果。
+- [ ] 3.7 AgentLoop：迭代结束时自动保存 session。
+- [ ] 3.8 AgentLoop：退出时清理所有后台进程。
+- [ ] 3.9 CLI：`--resume` 参数 + `session list/rm` 子命令。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行 artifact checker。
+- [ ] 4.5 手动验证：后台执行 sleep 10 命令并在中途用 TaskOutput 检查。
+- [ ] 4.6 手动验证：保存 session 后用 --resume 恢复。
+
+- [ ] 4.5 跑通至少一个 benchmark smoke，验证变更不影响 agent 执行正确性。
+
+## 5. PR 收尾
+
+- [ ] 5.1 归档到 `openspec/changes/archive/YYYY-MM-DD-add-background-task-execution-and-session-persistence/`。
+- [ ] 5.2 从 backlog 移除。
+- [ ] 5.3 确认 Impact Analysis 无残留未知项。
+- [ ] 5.4 运行全量校验。

--- a/openspec/changes/add-multimodal-input-support/design.md
+++ b/openspec/changes/add-multimodal-input-support/design.md
@@ -1,0 +1,160 @@
+## Context
+
+Message 协议的 core 数据类型是 `content: str`，所有上下游——LLM adapter、memory compaction、trace、subagent 传递——都假设纯文本。支持图片输入需要把这个假设升级为"content 可以是文本或 image_url blocks 的列表"，同时保持对纯文本路径的完全兼容。
+
+这项改造触及整个系统的消息传递链，是 6 个 change 中改动面最大的一个。
+
+## Decisions
+
+### 1. Content 协议设计
+
+```python
+from typing import Literal
+
+type ContentBlock = TextBlock | ImageBlock
+
+class TextBlock:
+    type: Literal["text"] = "text"
+    text: str
+
+class ImageBlock:
+    type: Literal["image_url"] = "image_url"
+    image_url: ImageUrl
+
+class ImageUrl:
+    url: str         # base64 data URL 或 HTTP URL
+    detail: str | None = None  # "auto" | "low" | "high" (OpenAI)
+```
+
+`Message.content` 类型变为 `str | list[ContentBlock]`。
+
+**向后兼容规则**：
+- 如果 `isinstance(content, str)` → 纯文本路径，所有现有代码不受影响。
+- 如果 `isinstance(content, list)` → 多模态路径。
+- 序列化时：`str` → `{"type": "text", "content": "..."}`；`list` → `[{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {...}}]`.
+
+### 2. Read 工具改动
+
+`Read` 工具执行流程：
+
+1. 检测文件扩展名：`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` → 图片路径。
+2. 读取文件字节，base64 编码。
+3. 返回 `[ImageBlock(url="data:image/png;base64,...")]` 而非文本字符串。
+4. 非图片文件保持现有文本返回行为。
+
+`Read` 工具的 `execute() -> str` 签名不变——图片的 content blocks 在 AgentLoop 层面转换为多模态消息格式，而非在工具返回值中直接编码。
+
+实际上：工具 `execute()` 仍然返回 `str`（对图片返回描述性文本如 `[image: screenshot.png, 1024x768]`），但 AgentLoop 在构建消息时检测到上一轮 Read 返回了图片标记，并使用对应的 content blocks 构建多模态消息。
+
+**替代方案**：在 `ToolResult` 中新增 `content_blocks: list[ContentBlock] | None` 字段，允许工具返回结构化的多模态内容。AgentLoop 在构建消息时使用 `content_blocks` 替代 `output` 字符串。这个方案改动更小，不需要 AgentLoop 去"猜测"哪些工具返回了图片。
+
+**采用替代方案**：`ToolResult` 新增 `content_blocks: list[ContentBlock] | None = None`。图片读取时 Read 工具填充 `content_blocks`，AgentLoop 使用它构建多模态消息。
+
+### 3. LLM Provider Adapter 改动
+
+**OpenAI API 格式**：
+```json
+{
+  "role": "user",
+  "content": [
+    {"type": "text", "text": "这个截图显示什么错误？"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+  ]
+}
+```
+
+**Anthropic API 格式**：
+```json
+{
+  "role": "user",
+  "content": [
+    {"type": "text", "text": "这个截图显示什么错误？"},
+    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "..."}}
+  ]
+}
+```
+
+Adapter 的 `_build_messages()` 方法需要：
+1. 检查 message 的 content 类型
+2. 如果是 `str` → 现有路径
+3. 如果是 `list[ContentBlock]` → 转换为 provider 专有的多模态格式
+4. 非视觉模型（如非 `gpt-4o`、非 Claude 3+）→ 对图片 block 降级为占位文本 `[image: <描述>]`
+
+### 4. 消息序列化影响
+
+所有序列化/反序列化 Message 的地方都需要处理 `content: str | list[ContentBlock]`：
+
+- **MemoryManager compact**：compact 时如遇到图片 content blocks，降级为文本占位符再传给 LLM 摘要（摘要 LLM 可能不支持视觉）。
+- **TraceRecorder**：图片 base64 数据不完整写入 trace（太大），替换为 `[image: <file_name>]` 引用。
+- **Subagent message passing**：图片 content blocks 原样传递（子 agent 使用相同的 LLM provider，支持多模态）。
+
+### 5. 图片大小限制
+
+- 单张图片最大 20MB（对齐 Claude API 限制）。
+- base64 编码后完整传递（不做压缩），由 LLM provider 侧处理尺寸优化。
+- 如果 Read 工具检测到超大图片，返回错误提示而不是静默截断。
+
+## Goals / Non-Goals
+
+- 不支持视频/音频输入。
+- 不支持图片生成或编辑。
+- 不支持 Web UI 中的图片粘贴/拖拽上传（后续 change）。
+- 不支持 prompt caching 对图片内容的优化（后续优化）。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 的 Read 工具如何处理图片？
+2. Anthropic API 和 OpenAI API 的多模态 content 格式差异？
+3. 非视觉模型的降级策略？
+
+- findings:
+
+- Claude Code 的 Read 工具检测图片文件扩展名，返回 `image_url` content block。Claude API 支持 `image` content block 类型（使用 `source.type: base64` + `media_type` + `data`）。
+- OpenAI API 使用 `image_url` content block，支持 `url`（HTTP 或 data URL）和可选 `detail` 参数（auto/low/high）。Anthropic API 使用 `image` type + `source` 对象。
+- 两个 API 的多模态格式差异较大，需要在 adapter 层做 provider-specific 转换。
+- 非视觉模型（如 `gpt-4`、`claude-3-haiku` 早期版本）不支持图片输入，需要降级处理。
+
+- design impact:
+
+- Message 协议层定义中立的 `ContentBlock` 格式（`text` + `image_url`），各 adapter 负责转换为 provider 格式。
+- Anthropic adapter 需要 `image_url` → `image` + `source` 的格式映射。
+- 降级策略使用占位文本而非直接报错，让 agent 至少知道"这里有一张图片"。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| Message 数据模型 | content 类型扩展，向后兼容 |
+| Read 工具 | 新增图片识别路径 |
+| OpenAI adapter | 新增 content list → OpenAI 多模态格式转换 |
+| Anthropic adapter | 新增 content list → Anthropic 多模态格式转换 |
+| MemoryManager | compact 时图片降级为文本占位 |
+| TraceRecorder | 图片 base64 替换为引用 |
+| Subagent | 图片原样传递 |
+| Web UI | 前端不需要改动（图片由 model 理解，UI 只展示文本） |
+| Benchmark | 不影响（benchmark 任务不涉及图片） |
+| 审批链路 | 审批请求中图片降级为文件名引用 |
+
+
+## Risks / Trade-offs
+
+- [Risk] Message.content 类型从 str 扩展到 union type 影响所有消息处理路径。Mitigation: 充分测试向后兼容性，所有现有测试必须无改动通过。
+- [Risk] 图片 base64 数据可能使 trace 文件膨胀。Mitigation: trace 中替换为引用，不存储完整 base64。
+- [Risk] 非视觉模型降级的占位文本可能让 agent 困惑。Mitigation: 占位文本明确说明"此处是一张图片"，并提示使用支持视觉的模型。
+
+## Testing Strategy
+
+- Message 序列化/反序列化：纯文本不变、多模态 content blocks 正确。
+- Read 工具：PNG/JPG 返回 ImageBlock、.py 文件仍返回文本、超大图片报错。
+- OpenAI/Anthropic adapter：content list → provider 格式转换正确。
+- 非视觉模型降级：图片转占位文本。
+- MemoryManager compact：图片降级为文本。
+- TraceRecorder：图片 base64 替换为引用。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/add-multimodal-input-support/proposal.md
+++ b/openspec/changes/add-multimodal-input-support/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+当前 Message 协议仅支持文本内容（`role + content: str`），所有 LLM provider adapter 也只处理纯文本。Asterwynd 的 agent 无法理解截图、架构图、UI mockup 等图片输入。
+
+Claude Code 支持通过 `Read` 工具读取图片文件并作为多模态输入传给模型，Copilot、Cursor、Cline 均提供图片理解和粘贴功能。多模态是 coding agent "能看懂 UI 截图定位 bug"的关键基础。
+
+## What Changes
+
+- `Message` 数据模型扩展：`content` 从 `str` 扩展为 `str | list[ContentBlock]`，`ContentBlock` 支持 `text` 和 `image_url` 两种类型。
+- `Read` 工具扩展：读取图片文件（PNG/JPG/GIF/WebP）时返回 `[image_url]` content block 而非文本。
+- LLM Provider Adapter 改动：
+  - OpenAI adapter：支持 `content: list[ContentBlock]` 格式。
+  - Anthropic adapter：支持 `content: list[ContentBlock]` 格式（含 `source` 字段映射）。
+- 向前兼容：现有 `content: str` 的用法不受影响，仅在涉及图片时使用新格式。
+- Message 序列化/反序列化（用于 trace、subagent 传递）支持多模态 content。
+
+不被认为是一个 breaking change——`content: str` 的所有现有路径保持不变。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: `Message` 协议扩展为支持多模态 content blocks。
+- `coding-tools`: `Read` 工具支持图片文件的识别和 base64 编码返回。
+
+## Impact
+
+- 影响代码：
+  - `agent/message.py`
+  - `agent/loop.py`（消息序列化/反序列化）
+  - `agent/llm/openai_adapter.py`
+  - `agent/llm/anthropic_adapter.py`
+  - `agent/tools/builtin/read.py`
+  - `agent/memory/manager.py`（compact 中的消息序列化）
+  - `agent/trace_recorder.py`（trace 中可能包含图片引用）
+  - `agent/subagent/`（父子 agent 消息传递）
+- 影响测试：
+  - `tests/agent/test_message.py`
+  - `tests/agent/llm/test_openai_adapter.py`
+  - `tests/agent/llm/test_anthropic_adapter.py`
+  - `tests/agent/tools/test_read.py`
+  - `tests/agent/test_loop.py`
+
+## Change Type
+
+- primary: feature
+- secondary: refactor

--- a/openspec/changes/add-multimodal-input-support/specs/agent-runtime/spec.md
+++ b/openspec/changes/add-multimodal-input-support/specs/agent-runtime/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: 多模态 Message 内容
+
+Message 的 `content` 字段 SHALL 支持 `str`（纯文本）和 `list[ContentBlock]`（多模态）两种类型。`ContentBlock` SHALL 支持 `text` 和 `image_url` 两种类型。`str` 类型 SHALL 保持完全向后兼容。
+
+#### Scenario: 纯文本内容不变
+
+- **GIVEN** Message 的 content 为 `str` 类型
+- **WHEN** 任意现有代码路径处理该 Message
+- **THEN** 行为 SHALL 与改动前完全一致
+
+#### Scenario: 多模态 content 序列化
+
+- **GIVEN** Message 的 content 为 `[TextBlock("解读这张图"), ImageBlock(url="data:image/png;base64,...")]`
+- **WHEN** 序列化为 JSON
+- **THEN** content SHALL 序列化为 content blocks 数组
+- **AND** deserialize 后 SHALL 还原为相同的 content blocks 数组
+
+### Requirement: ToolResult 多模态内容
+
+`ToolResult` SHALL 新增 `content_blocks: list[ContentBlock] | None` 字段。当工具返回了图片或其他非文本内容时，`content_blocks` SHALL 携带结构化内容。AgentLoop 在构建消息时 SHALL 优先使用 `content_blocks`。
+
+#### Scenario: Read 工具读取图片
+
+- **GIVEN** Read 工具读取了一个 PNG 文件
+- **WHEN** 工具执行完成
+- **THEN** ToolResult.content_blocks SHALL 包含一个 ImageBlock
+- **AND** AgentLoop 在构建消息时 SHALL 使用该 ImageBlock
+
+#### Scenario: 普通文本工具结果
+
+- **GIVEN** Read 工具读取了一个 .py 文件
+- **WHEN** 工具执行完成
+- **THEN** ToolResult.content_blocks SHALL 为 None
+- **AND** AgentLoop 在构建消息时 SHALL 使用 ToolResult.output（文本）

--- a/openspec/changes/add-multimodal-input-support/specs/coding-tools/spec.md
+++ b/openspec/changes/add-multimodal-input-support/specs/coding-tools/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Read 工具支持图片文件
+
+`Read` 工具 SHALL 根据文件扩展名（`.png`、`.jpg`、`.jpeg`、`.gif`、`.webp`）检测图片文件。检测到图片时 SHALL 读取文件字节、base64 编码、并填充 `ToolResult.content_blocks` 为 `ImageBlock`。
+
+#### Scenario: 读取 PNG 图片
+
+- **GIVEN** 路径指向一个有效的 PNG 文件
+- **WHEN** agent 调用 Read 工具
+- **THEN** ToolResult SHALL 包含 `[ImageBlock(url="data:image/png;base64,...")]`
+- **AND** ToolResult.output SHALL 包含描述性文本（文件名、尺寸）
+
+#### Scenario: 读取代码文件保持不变
+
+- **GIVEN** 路径指向一个 .py 文件
+- **WHEN** agent 调用 Read 工具
+- **THEN** ToolResult SHALL 仅包含文本 output
+- **AND** content_blocks SHALL 为 None
+
+#### Scenario: 超大图片
+
+- **GIVEN** 图片文件超过 20MB
+- **WHEN** agent 调用 Read 工具
+- **THEN** Read SHALL 返回错误，提示图片过大

--- a/openspec/changes/add-multimodal-input-support/tasks.md
+++ b/openspec/changes/add-multimodal-input-support/tasks.md
@@ -1,0 +1,52 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `agent-runtime` spec delta：定义多模态 Message content 协议。
+- [ ] 1.2 更新 `coding-tools` spec delta：定义 Read 工具的图片处理行为。
+- [ ] 1.3 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.4 维护 `## Impact Analysis`。
+- [ ] 1.5 维护 `## Reference Implementation Research`。
+
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+
+## 2. 测试
+
+- [ ] 2.1 Message 序列化测试：纯文本 content 序列化/反序列化不变。
+- [ ] 2.2 Message 序列化测试：多模态 content blocks 序列化/反序列化正确。
+- [ ] 2.3 Read 工具测试：读取 PNG/JPG 返回 ImageBlock。
+- [ ] 2.4 Read 工具测试：读取 .py 文件仍返回 TextBlock。
+- [ ] 2.5 Read 工具测试：超大图片（>20MB）返回错误。
+- [ ] 2.6 OpenAI adapter 测试：content list → OpenAI 多模态请求格式。
+- [ ] 2.7 Anthropic adapter 测试：content list → Anthropic 多模态请求格式。
+- [ ] 2.8 非视觉模型降级测试：图片转换为占位文本。
+- [ ] 2.9 MemoryManager compact 测试：图片 content 降级为文本占位。
+- [ ] 2.10 TraceRecorder 测试：trace 中图片 base64 被替换为引用。
+
+## 3. 实现
+
+- [ ] 3.1 定义 `ContentBlock`、`TextBlock`、`ImageBlock`、`ImageUrl` 数据类（`agent/message.py`）。
+- [ ] 3.2 `Message.content` 类型扩展为 `str | list[ContentBlock]`。
+- [ ] 3.3 `ToolResult` 新增 `content_blocks: list[ContentBlock] | None`。
+- [ ] 3.4 `Read` 工具：图片检测 + base64 编码 + 填充 content_blocks。
+- [ ] 3.5 `AgentLoop` ：构建消息时使用 `content_blocks`。
+- [ ] 3.6 OpenAI adapter：`_build_messages()` 支持 content list。
+- [ ] 3.7 Anthropic adapter：`_build_messages()` 支持 content list + image source 映射。
+- [ ] 3.8 MemoryManager：compact 时图片降级。
+- [ ] 3.9 TraceRecorder：图片 base64 替换为引用。
+- [ ] 3.10 Subagent message passing：图片原样传递。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行 artifact checker。
+- [ ] 4.5 手动验证：用支持视觉的模型读取一个测试图片。
+
+- [ ] 4.5 跑通至少一个 benchmark smoke，验证变更不影响 agent 执行正确性。
+
+## 5. PR 收尾
+
+- [ ] 5.1 归档到 `openspec/changes/archive/YYYY-MM-DD-add-multimodal-input-support/`。
+- [ ] 5.2 从 backlog 移除。
+- [ ] 5.3 确认 Impact Analysis 无残留未知项。
+- [ ] 5.4 运行全量校验。

--- a/openspec/changes/add-parallel-tool-execution/design.md
+++ b/openspec/changes/add-parallel-tool-execution/design.md
@@ -1,0 +1,122 @@
+## Context
+
+`AgentLoop._execute_tool_calls()` 当前实现（`agent/loop.py:284-340`）对每个 tool call 逐个 await，即使多个 call 之间完全独立。在 coding-agent 场景中，agent 经常在第一步发出多个只读探索调用（读多个文件、搜索代码、检查目录），这些调用之间没有数据依赖，并行执行可显著加速。
+
+## Decisions
+
+### 1. 可并行工具识别
+
+`Tool` 基类新增 `parallelizable: bool = False`。
+
+只读且无副作用的工具标记为 `True`：
+- `Read`, `Grep`, `Find`, `ListFiles`
+- `LspDefinition`, `LspReferences`, `LspHover`, `LspDocumentSymbols`, `LspWorkspaceSymbols`, `LspDiagnostics`
+- `WebFetch`, `WebSearch`
+- `RepoMap`, `SymbolSearch`
+- `InspectGitDiff`
+
+以下工具保持 `False`：
+- `Write`, `Edit` — 文件写操作，两个并发写可能冲突
+- `Bash` — 命令可能有文件副作用
+- `UpdatePlan`, `ExitPlanMode`, `TodoWrite` — 改变 agent state
+- 所有 subagent 工具 — 启动子 agent 有副作用
+- `ActivateSkill` — 状态变更
+
+### 2. 执行策略：分组并行
+
+```python
+async def _execute_tool_calls(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
+    groups = self._group_by_parallelizable(tool_calls)
+    results = []
+    for group in groups:
+        if group[0].parallelizable:
+            group_results = await asyncio.gather(*[self._execute_one(tc) for tc in group])
+        else:
+            group_results = [await self._execute_one(tc) for tc in group]
+        results.extend(group_results)
+    return results
+```
+
+分组逻辑：连续的可并行 call 归入一组（从第一个可并行 call 开始到最后一个连续的可并行 call 结束），可并行组前面的串行 call 自成一组，可并行组后面的串行 call 自成一组。
+
+例如：`[Bash, Read, Read, Grep, Write, Read]` → 分组为 `[[Bash], [Read, Read, Grep], [Write], [Read]]`。
+
+### 3. 结果顺序保持
+
+无论执行顺序如何，最终 tool result 列表必须与原始 tool call 顺序一致。TraceRecorder 在每个并行段开始时记录 `parallel_execution_start` step，段结束时记录每个 call 的 `tool_result` step。
+
+### 4. 错误隔离
+
+并行组内某个 tool call 失败不影响其他 call 继续执行。`asyncio.gather(return_exceptions=True)` 确保一个超时不拖慢整个组。
+
+### 5. 与审批系统的交互
+
+并行组中如果任意 tool call 需要审批，整组分两种策略：
+- **简单策略（先采用）**：并行组中任一需要审批时，退化为串行逐一通过审批 gate。
+- **优化策略（后续）**：一次审批列出组内所有 tool call，用户一次性批准/拒绝整个组。
+
+考虑到并行组通常只包含只读工具（low risk, auto-approve），大部分情况不触发审批。先采用简单策略。
+
+### 6. 与错误重试的交互
+
+并行组中的工具独立重试。如果组内两个 call 都因瞬时错误失败，各自独立走 Change 1 的 retry 路径。
+
+## Goals / Non-Goals
+
+- 不改变 LLM 调用层面的并发（仍然是单次 LLM 调用 → 多 tool call → 执行 → 下一次 LLM 调用）。
+- 不引入跨迭代的并行（不同 iteration 仍然串行）。
+- 不支持工具间的依赖声明或编排。
+- 不支持 Bash 命令的并行执行。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 如何实现并行工具执行？
+2. Codex 的工具执行模型是怎样的？
+3. 并行执行是否需要工具级声明，还是全部自动并行？
+
+- findings:
+
+- Claude Code 的 AgentLoop 在一次迭代内对独立的 Read/Grep/Glob 调用做并行执行。工具协议中没有显式的 "parallelizable" 标记，而是基于工具能力判断：READ 类操作可并行，WRITE 类不可。
+- Codex 模型本身在单个响应中发出多个 tool call 时，runtime 对只读做并行。
+- Aider 不使用并行 tool calls，其 edit format 是序列化的。
+
+- design impact:
+
+- 选择显式 `parallelizable` 标记而非自动推断，避免向模型暴露不必要的实现细节，同时给未来扩展保留空间。
+- 分组并行策略（连续只读合并为一组）是最简单且安全的方式。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| AgentLoop 工具执行路径 | 核心改动，需充分测试 |
+| Tool 基类 | 新增属性，向后兼容 |
+| TraceRecorder | 新增并行段 step 类型 |
+| 审批链路 | 并行组退化策略 |
+| 错误重试（Change 1） | 并行组中独立重试 |
+| Benchmark | 可能导致相同任务耗时变短、轮次减少 |
+| MCP 工具 | MCP 工具默认 `parallelizable=False` |
+| TUI/Web | 并行执行展示可能需要调整 |
+
+
+## Risks / Trade-offs
+
+- [Risk] 并行 Read + 串行 Write 的分组逻辑在复杂 tool call 序列下可能产生意外顺序。Mitigation: 充分测试混合分组，TUI trace 面板清楚展示分组边界。
+- [Risk] LLM 不知道工具是并行执行的，可能发出有隐式数据依赖的调用。Mitigation: 文档说明模型不应依赖执行时序，所有只读工具语义上独立。
+- [Risk] 并行组审批退化可能让用户体验不一致。Mitigation: 大部分并行组是只读工具（auto-approve），退化实际很少触发。
+
+## Testing Strategy
+
+- 分组逻辑单元测试：全并行、混合分组、连续可并行+串行。
+- AgentLoop 集成测试：并行组错误隔离、结果顺序保持、审批退化。
+- 只读工具标记测试：Read/Grep/Find 等标记为 parallelizable。
+- 写工具标记测试：Write/Edit/Bash 不标记为 parallelizable。
+- 与 retry 交互测试：并行组内独立重试。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/add-parallel-tool-execution/proposal.md
+++ b/openspec/changes/add-parallel-tool-execution/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+当前 `AgentLoop._execute_tool_calls()` 在单次迭代内串行执行所有 tool call。当 agent 在同一轮发出多个独立的只读工具调用（例如 Read + Grep + Find），它们应该可以并行执行以缩短迭代耗时。
+
+Claude Code 的 AgentLoop 支持并行执行独立工具调用（例如同时读多个文件），Codex 和 Aider 同理。这直接减少 agent 完成任务的总轮次和耗时，对 benchmark `max_iterations` 失败类有直接改善。
+
+## What Changes
+
+- `AgentLoop._execute_tool_calls()` 改为：识别可并行工具 → `asyncio.gather` 并发执行 → 不可并行工具串行执行 → 结果按原始顺序返回。
+- `Tool` 基类新增 `parallelizable: bool` 属性（默认 `False`），只读工具（Read/Write?No, Read/Grep/Find/ListFiles/Lsp*/WebFetch/WebSearch/RepoMap/SymbolSearch）标记为 `True`。
+- 写工具（Write/Edit/Bash）和状态工具（UpdatePlan/ExitPlanMode/TodoWrite/subagent tools）保持串行。
+- TraceRecorder 记录每个并行执行段的开始和结束，保持调用顺序语义。
+
+不被认为是一个 breaking change——工具执行的结果语义不变，仅执行时序变化。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: `AgentLoop` 工具执行路径从串行改为可并行。
+- `tool-system`: `Tool` 基类新增 `parallelizable` 声明。
+
+## Impact
+
+- 影响代码：
+  - `agent/loop.py`（核心改动）
+  - `agent/tools/base.py`（`parallelizable` 属性）
+  - `agent/tools/builtin/*.py`（各工具标记）
+  - `agent/trace_recorder.py`
+- 影响测试：
+  - `tests/agent/test_loop.py`
+  - `tests/agent/tools/test_*`
+- 不影响：LLM provider 协议、workspace safety、benchmark runner、MCP 集成、审批链路。
+
+## Change Type
+
+- primary: feature
+- secondary: refactor

--- a/openspec/changes/add-parallel-tool-execution/specs/agent-runtime/spec.md
+++ b/openspec/changes/add-parallel-tool-execution/specs/agent-runtime/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: 工具调用并行执行
+
+AgentLoop SHALL 在一次迭代内对连续的 `parallelizable` 工具调用执行并发执行。不可并行的工具调用 SHALL 保持串行。并发组中任一工具调用失败 SHALL NOT 影响组内其他工具调用。所有工具执行完成后 SHALL 按原始 tool call 顺序返回结果。
+
+#### Scenario: 全并行组
+
+- **GIVEN** 单次迭代中有 3 个 tool call 均为 `parallelizable`
+- **WHEN** AgentLoop 执行这些 tool call
+- **THEN** 3 个 call SHALL 在同一组中并发执行
+- **AND** 结果 SHALL 按原始顺序排列
+
+#### Scenario: 混合分组
+
+- **GIVEN** tool call 序列为 `[Edit, Read, Read, Bash]`（Edit 和 Bash 不可并行，Read 可并行）
+- **WHEN** AgentLoop 执行这些 tool call
+- **THEN** 分组 SHALL 为 `[[Edit], [Read, Read], [Bash]]`
+- **AND** 每组内部串行或并行执行
+
+#### Scenario: 并行组错误隔离
+
+- **GIVEN** 并行组内有 2 个 Read 调用，其中一个因文件不存在失败
+- **WHEN** 并行组执行完成
+- **THEN** 成功的 Read SHALL 返回文件内容
+- **AND** 失败的 Read SHALL 返回错误
+- **AND** 两个结果 SHALL 均出现在最终结果列表中
+
+#### Scenario: 并行组审批退化
+
+- **GIVEN** 并行组内有一个工具需要审批
+- **WHEN** AgentLoop 准备执行并行组
+- **THEN** 整组 SHALL 退化为串行执行
+- **AND** 每个工具 SHALL 逐一通过审批 gate
+
+#### Scenario: 结果顺序保持
+
+- **GIVEN** 原始 tool call 顺序为 `[Grep, Read, Find]`（全部可并行）
+- **WHEN** 并发执行完成
+- **THEN** 返回结果 SHALL 保持 `[GrepResult, ReadResult, FindResult]` 顺序

--- a/openspec/changes/add-parallel-tool-execution/specs/tool-system/spec.md
+++ b/openspec/changes/add-parallel-tool-execution/specs/tool-system/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: 工具并行执行标记
+
+Tool 基类 SHALL 新增 `parallelizable` 属性。只读且无副作用的工具 SHALL 标记 `parallelizable = True`。写操作、状态变更和有副作用的工具 SHALL NOT 标记为可并行。
+
+#### Scenario: 只读工具可并行
+
+- **GIVEN** 一个 `Read` 工具实例
+- **WHEN** 查询 `parallelizable` 属性
+- **THEN** 返回值 SHALL 为 `True`
+
+#### Scenario: 写工具不可并行
+
+- **GIVEN** 一个 `Edit` 工具实例
+- **WHEN** 查询 `parallelizable` 属性
+- **THEN** 返回值 SHALL 为 `False`
+
+#### Scenario: MCP 工具默认不可并行
+
+- **GIVEN** 一个 MCP 工具实例
+- **WHEN** 查询 `parallelizable` 属性
+- **THEN** 返回值 SHALL 为 `False`（除非 MCP server 显式声明）

--- a/openspec/changes/add-parallel-tool-execution/tasks.md
+++ b/openspec/changes/add-parallel-tool-execution/tasks.md
@@ -1,0 +1,43 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `agent-runtime` spec delta：定义并行工具执行行为和分组策略。
+- [ ] 1.2 更新 `tool-system` spec delta：定义 `parallelizable` 属性和可并行工具列表。
+- [ ] 1.3 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.4 维护 `## Impact Analysis`。
+- [ ] 1.5 维护 `## Reference Implementation Research`。
+
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+
+## 2. 测试
+
+- [ ] 2.1 AgentLoop 单元测试：全部可并行工具在一组中并发执行。
+- [ ] 2.2 AgentLoop 单元测试：混合串行+并行工具的分组执行。
+- [ ] 2.3 AgentLoop 单元测试：并行组中一个工具失败不影响其他。
+- [ ] 2.4 AgentLoop 单元测试：并行组中任一需要审批时退化串行。
+- [ ] 2.5 AgentLoop 单元测试：结果顺序与原始 tool call 顺序一致。
+- [ ] 2.6 AgentLoop 单元测试：两个 Write 工具在不同组中串行执行。
+- [ ] 2.7 与 Change 1 retry 交互测试：并行组中独立重试。
+
+## 3. 实现
+
+- [ ] 3.1 在 `Tool` 基类新增 `parallelizable: bool = False`。
+- [ ] 3.2 标记所有只读工具的 `parallelizable = True`。
+- [ ] 3.3 实现 `AgentLoop._execute_tool_calls` 分组并行逻辑。
+- [ ] 3.4 实现并行组审批退化策略。
+- [ ] 3.5 TraceRecorder 新增 `parallel_execution` step 类型。
+- [ ] 3.6 如果 TUI/Web 展示受影响，同步更新。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行 artifact checker。
+- [ ] 4.5 跑通至少一个 benchmark smoke，验证并行执行不影响正确性。
+
+## 5. PR 收尾
+
+- [ ] 5.1 归档到 `openspec/changes/archive/YYYY-MM-DD-add-parallel-tool-execution/`。
+- [ ] 5.2 从 backlog 移除。
+- [ ] 5.3 确认 Impact Analysis 无残留未知项。
+- [ ] 5.4 运行全量校验。

--- a/openspec/changes/add-persistent-cross-session-memory/design.md
+++ b/openspec/changes/add-persistent-cross-session-memory/design.md
@@ -1,0 +1,160 @@
+## Context
+
+当前 MemoryManager 在每次 compact 时用 LLM 生成对话摘要并插入 system 消息，但摘要仅在当前 session 有效。Session 结束后对话历史、LLM 摘要全部丢弃。为了让 agent 在后续 session 中了解用户偏好和历史决策，需要覆盖跨 session 的持久层。
+
+## Decisions
+
+### 1. 存储格式与位置
+
+与 Claude Code 的 memory 格式兼容：
+
+```markdown
+---
+name: user-role
+description: 用户的角色和偏好
+metadata:
+  type: user
+---
+
+用户是后端工程师，偏好 Go 和 Python。在解释代码时希望从调用链角度理解。
+```
+
+存储位置：`~/.claude/projects/<project-hash>/memory/`（复用 Claude Code 的路径结构，方便互操作）。
+
+四类记忆：
+- `user`：用户角色、偏好、知识背景
+- `feedback`：用户给出的反馈和规则（"不要 mock 数据库"、"测试要覆盖 X"）
+- `project`：项目相关的非代码信息（"下周五上线"、"legal 要求改 auth"）
+- `reference`：外部资源指针（"bug 在 Linear INGEST 项目"、"Grafana 面板在 XX URL"）
+
+### 2. 记忆索引 MEMORY.md
+
+`MEMORY.md` 是索引文件，每行一条：
+```markdown
+- [用户角色](user_role.md) — 后端工程师，偏好 Go/Python，希望从调用链角度理解代码
+- [测试规范](feedback_testing.md) — 集成测试必须连真实数据库，不要 mock
+```
+
+AgentLoop 启动时优先读取 `MEMORY.md`，如果索引中指向的文件存在则读取内容，把所有记忆内容串联为单个上下文块。
+
+### 3. SaveMemory 工具设计
+
+```
+SaveMemory(type, name, description, body)
+```
+
+- `type`: user | feedback | project | reference
+- `name`: kebab-case slug，作为文件名（如 `user_role.md`）
+- `description`: 一行摘要，写入 MEMORY.md 索引行
+- `body`: 记忆正文（含 YAML frontmatter 外的 Markdown 内容）
+
+工具写入两个文件：
+1. `<name>.md` — 完整的记忆文件
+2. 更新 `MEMORY.md` — 追加或更新索引行
+
+如果 name 已存在，更新而不是重复创建。
+
+### 4. RecallMemory 工具设计
+
+```
+RecallMemory(type=None)
+```
+
+- 读取 `MEMORY.md` 索引
+- 可选按 type 过滤
+- 返回每条记忆的完整内容（含 frontmatter）
+- 不传 type 时返回全部记忆全文
+
+### 5. 记忆注入策略
+
+AgentLoop 在 `_messages_with_run_context()` 中新增一个注入段：
+
+```
+## Project Memory
+The following persistent memories from prior sessions are relevant to this project:
+---
+[记忆 1 的 full body]
+---
+[记忆 2 的 full body]
+---
+```
+
+注入位置：在所有系统消息之后、技能上下文之前。
+
+注入时机：仅在存在至少一条记忆时注入。如果 `MEMORY.md` 不存在或为空，不注入。
+
+### 6. 与 session 内 compact 的关系
+
+两层记忆独立：
+- `MemoryManager`（compact）：session 内短期内存，会被 compact 压缩/裁剪，session 结束后丢弃。
+- `PersistentMemory`：跨 session 长期记忆，由用户或 agent 显式写入文件，保持不变直到被更新或删除。
+
+两者不直接通信。AgentLoop 在构建系统消息时同时注入两者的产物。
+
+### 7. 自动记忆
+
+Agent 可以根据对话内容自主判断何时调用 `SaveMemory`。AGENTS.md / CLAUDE.md 中的 instructions 会引导 agent 在何时保存记忆（类似 Claude Code 的 auto-memory 机制）。
+
+## Goals / Non-Goals
+
+- 不支持向量化/语义检索记忆（当前阶段使用全文读取）。
+- 不支持记忆的版本历史或 diff。
+- 不支持记忆冲突检测或多用户协作。
+- 不支持 `SaveMemory` 自动合并相似记忆。
+- 不替代 `MemoryManager` 的 session 内 compact。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 的 memory 系统如何工作（文件格式、类型、读写机制）？
+2. Codex 的 CODEBUDDY.md 机制如何运作？
+3. 跨 session 记忆的注入时机和上下文 window 管理？
+
+- findings:
+
+- Claude Code 使用 `~/.claude/projects/<hash>/memory/` 目录结构，`MEMORY.md` 作为索引，每个记忆独立一个 `.md` 文件。四类记忆（user/feedback/project/reference）通过 frontmatter 的 `metadata.type` 字段区分。
+- Claude Code 的记忆文件有 YAML frontmatter（name, description, metadata.type），正文是 Markdown。
+- Claude Code 的 auto-memory 指令引导 agent 在特定触发条件下自动写入记忆（用户纠正、确认非平凡选择、项目决策等）。
+- Codex 使用 `CODEBUDDY.md` 作为项目级持久记忆文件，与 Claude Code 的 MEMORY.md 类似但格式更简单。
+- Cursor 的 `.cursorrules` 是项目级行为配置文件，偏向指令而非记忆。
+
+- design impact:
+
+- 文件格式直接对齐 Claude Code，确保记忆文件互操作。
+- 存储路径复用 `~/.claude/projects/` 结构，避免另起一套。
+- 记忆类型和触发条件参考 Claude Code 的 auto-memory 指令。
+- 当前阶段不做向量检索是因为记忆量级不大（几十条），全文读取成本可控。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| Memory 模块 | 新增 PersistentMemory 类 |
+| AgentLoop 系统消息构建 | 新增记忆注入段 |
+| ToolRegistry | 新增 SaveMemory / RecallMemory |
+| Session 内 compact | 不影响 |
+| MCP | 不影响 |
+| Benchmark | 不影响（benchmark 使用临时 workspace，无记忆目录） |
+| TUI/Web | 后续可选展示记忆面板 |
+
+
+## Risks / Trade-offs
+
+- [Risk] 记忆文件与 Claude Code 格式兼容但路径相同，两个工具可能互相覆盖。Mitigation: 使用相同的 MEMORY.md 索引文件，自然共享记忆。
+- [Risk] 记忆文件手动编辑后 frontmatter 损坏导致解析失败。Mitigation: 解析失败时跳过该记忆并记录警告，不阻止其他记忆加载。
+- [Risk] 全文读取所有记忆可能在记忆量大时增加 token 消耗。Mitigation: 当前阶段量小，后续可改为摘要注入或 RAG 检索。
+
+## Testing Strategy
+
+- PersistentMemory 单元测试：写入/更新/读取记忆、MEMORY.md 不存在时返回空。
+- SaveMemory 工具测试：四类记忆创建、同名更新。
+- RecallMemory 工具测试：全量和按 type 过滤。
+- AgentLoop 集成：有记忆时注入 `## Project Memory`、无记忆时不注入。
+- 文件兼容性测试：YAML frontmatter 合法性。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/add-persistent-cross-session-memory/proposal.md
+++ b/openspec/changes/add-persistent-cross-session-memory/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+当前 `MemoryManager` 只做 session 内的 AutoCompact，没有跨 session 的持久记忆。每次新 session 开始，agent 对用户偏好、项目约定、历史决策一无所知。
+
+Claude Code 有 `MEMORY.md` 自动记忆系统（`user/feedback/project/reference` 四类），Codex 有 `CODEBUDDY.md`，Cursor 有 `.cursorrules`。这些机制让 agent 在多次交互中逐步了解用户和项目，是 coding agent "越来越懂你的项目" 叙事的基础。
+
+Asterwynd 的 AgentLoop 已经在系统消息中注入技能上下文（`_messages_with_run_context`），可复用同一条注入路径接入持久记忆。
+
+## What Changes
+
+- 新增 `agent/memory/persistent.py`：`PersistentMemory` 类，管理 `user/feedback/project/reference` 四类记忆文件。
+- 记忆存储：`~/.claude/projects/<project-hash>/memory/MEMORY.md`（索引）+ 各类型 `.md` 文件（与 Claude Code 兼容格式）。
+- 内置工具：
+  - `SaveMemory`：写入一条记忆到对应类型文件。参数：`type`（user/feedback/project/reference）、`name`（kebab-case slug）、`description`（一行摘要）、`body`（内容）。
+  - `RecallMemory`：读取并展示当前所有记忆的索引和内容。参数：可选的 `type` 过滤。
+- AgentLoop 在每次 run 开始时通过 `PersistentMemory.load_context()` 读取所有记忆文件内容，注入系统消息（在技能上下文之前）。
+- 记忆文件格式与 Claude Code 兼容（YAML frontmatter + 正文），方便未来迁移和对比。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `memory-context`: 从 "session 内 compaction" 扩展到 "session 内 compaction + 跨 session 持久记忆"。
+- `tool-system`: 新增 `SaveMemory`、`RecallMemory` 工具。
+
+## Impact
+
+- 影响代码：
+  - `agent/memory/persistent.py`（新增）
+  - `agent/tools/builtin/memory.py`（新增）
+  - `agent/tools/factory.py`
+  - `agent/loop.py`（`_messages_with_run_context` 注入记忆上下文）
+- 影响测试：
+  - `tests/agent/memory/test_persistent.py`
+  - `tests/agent/tools/test_memory_tools.py`
+  - `tests/agent/test_loop.py`
+- 不影响：session 内 compaction（`MemoryManager` 不变）、workspace safety、benchmark runner。
+
+## Change Type
+
+- primary: feature

--- a/openspec/changes/add-persistent-cross-session-memory/specs/memory-context/spec.md
+++ b/openspec/changes/add-persistent-cross-session-memory/specs/memory-context/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: 跨 session 持久记忆
+
+系统 SHALL 支持通过 `PersistentMemory` 在 `~/.claude/projects/<project-hash>/memory/` 目录下维护跨 session 的持久记忆。记忆 SHALL 分为 `user`、`feedback`、`project`、`reference` 四类，每类记忆存储为一个独立 `.md` 文件，`MEMORY.md` SHALL 作为索引文件。
+
+#### Scenario: 记忆写入
+
+- **GIVEN** 当前项目 memory 目录不存在或为空
+- **WHEN** agent 调用 SaveMemory 写入一条 type=user 的记忆
+- **THEN** 系统 SHALL 创建 `<name>.md` 文件，内容包含 YAML frontmatter 和正文
+- **AND** 系统 SHALL 在 MEMORY.md 中追加索引行
+
+#### Scenario: 记忆更新
+
+- **GIVEN** 已存在一条 name 为 `user_role` 的记忆
+- **WHEN** agent 调用 SaveMemory 且 name 为 `user_role`
+- **THEN** 系统 SHALL 更新 `<name>.md` 文件内容
+- **AND** 系统 SHALL 更新 MEMORY.md 中对应的索引行
+
+#### Scenario: 记忆读取
+
+- **GIVEN** MEMORY.md 包含 3 条索引，对应 3 个有效记忆文件
+- **WHEN** AgentLoop 启动
+- **THEN** PersistentMemory SHALL 读取全部 3 条记忆的全文
+- **AND** 内容 SHALL 注入到系统消息中
+
+#### Scenario: 无记忆时不注入
+
+- **GIVEN** 当前项目 memory 目录不存在或 MEMORY.md 为空
+- **WHEN** AgentLoop 启动
+- **THEN** 系统消息 SHALL NOT 包含 `## Project Memory` 段
+
+#### Scenario: 索引指向已删除文件
+
+- **GIVEN** MEMORY.md 索引行指向的 `.md` 文件已被手动删除
+- **WHEN** PersistentMemory 尝试读取该文件
+- **THEN** 系统 SHALL 跳过该条目
+- **AND** 不阻止其他有效记忆的加载
+
+### Requirement: SaveMemory 工具
+
+系统 SHALL 提供 `SaveMemory` 工具。参数 SHALL 包含 `type`（user/feedback/project/reference）、`name`（kebab-case slug）、`description`（一行摘要）、`body`（Markdown 正文）。
+
+#### Scenario: 写入记忆更新 MEMORY.md 索引
+
+- **GIVEN** 当前 memory 目录存在且 MEMORY.md 已有其他条目
+- **WHEN** agent 调用 SaveMemory 写入一条 type=user 的记忆
+- **THEN** MEMORY.md SHALL 新增一行索引
+- **AND** 对应 `.md` 文件 SHALL 包含合法的 YAML frontmatter 和正文
+
+### Requirement: RecallMemory 工具
+
+系统 SHALL 提供 `RecallMemory` 工具。参数 SHALL 包含可选的 `type` 过滤。不传 `type` 时 SHALL 返回全部记忆的完整内容。
+
+#### Scenario: 按类型读取记忆
+
+- **GIVEN** 存在 user 类型记忆 2 条、project 类型记忆 1 条
+- **WHEN** agent 调用 RecallMemory(type="user")
+- **THEN** 系统 SHALL 返回 2 条 user 记忆的完整内容
+- **AND** 不返回 project 类型记忆

--- a/openspec/changes/add-persistent-cross-session-memory/specs/tool-system/spec.md
+++ b/openspec/changes/add-persistent-cross-session-memory/specs/tool-system/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: SaveMemory 工具
+
+SaveMemory SHALL 支持 `create` 和 `update` 语义（name 不存在时创建，已存在时更新）。SaveMemory SHALL 写入对应的 `.md` 记忆文件和 `MEMORY.md` 索引行。工具能力 SHALL 标记为 `AGENT_STATE` / `MEDIUM` risk。
+
+#### Scenario: 创建新记忆
+
+- **GIVEN** name 为 `user_role` 的记忆不存在
+- **WHEN** agent 调用 SaveMemory(type="user", name="user_role", description="用户角色", body="...")
+- **THEN** 系统 SHALL 创建 `user_role.md`
+- **AND** MEMORY.md SHALL 新增一行索引
+
+#### Scenario: 更新已有记忆
+
+- **GIVEN** name 为 `user_role` 的记忆已存在
+- **WHEN** agent 调用 SaveMemory 使用相同 name
+- **THEN** 系统 SHALL 覆盖原有内容
+- **AND** MEMORY.md SHALL 更新对应索引行
+
+### Requirement: RecallMemory 工具
+
+RecallMemory SHALL 读取 MEMORY.md 索引和对应记忆文件。可选 type 过滤。返回全部记忆全文。工具能力 SHALL 标记为 `WORKSPACE_READ` / `LOW` risk（只读外部文件）。
+
+#### Scenario: 读取全部记忆
+
+- **GIVEN** 存在 user、project 各 1 条记忆
+- **WHEN** agent 调用 RecallMemory() 不传 type
+- **THEN** 系统 SHALL 返回 2 条记忆的完整内容
+
+#### Scenario: 按类型过滤
+
+- **GIVEN** 存在 user 记忆 1 条、project 记忆 2 条
+- **WHEN** agent 调用 RecallMemory(type="project")
+- **THEN** 系统 SHALL 返回 2 条 project 记忆

--- a/openspec/changes/add-persistent-cross-session-memory/tasks.md
+++ b/openspec/changes/add-persistent-cross-session-memory/tasks.md
@@ -1,0 +1,44 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `memory-context` spec delta：定义跨 session 持久记忆模型、存储格式、注入语义。
+- [ ] 1.2 更新 `tool-system` spec delta：定义 SaveMemory / RecallMemory 工具行为。
+- [ ] 1.3 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.4 维护 `## Impact Analysis`。
+- [ ] 1.5 维护 `## Reference Implementation Research`。
+
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+
+## 2. 测试
+
+- [ ] 2.1 PersistentMemory 单元测试：写入新记忆文件、更新已有记忆、读取 MEMORY.md 索引。
+- [ ] 2.2 PersistentMemory 单元测试：MEMORY.md 不存在时返回空上下文。
+- [ ] 2.3 SaveMemory 工具测试：创建 user/feedback/project/reference 四类记忆。
+- [ ] 2.4 RecallMemory 工具测试：按 type 过滤、无 type 返回全部。
+- [ ] 2.5 AgentLoop 集成测试：存在记忆时注入 `## Project Memory` 段。
+- [ ] 2.6 AgentLoop 集成测试：不存在记忆时不注入。
+- [ ] 2.7 文件格式兼容性测试：生成的 `.md` 文件有合法的 YAML frontmatter。
+
+## 3. 实现
+
+- [ ] 3.1 实现 `agent/memory/persistent.py` —— PersistentMemory 类。
+- [ ] 3.2 实现 `agent/tools/builtin/memory.py` —— SaveMemory / RecallMemory 工具。
+- [ ] 3.3 在 `factory.py` 注册 memory 工具到所有 mode。
+- [ ] 3.4 在 AgentLoop `_messages_with_run_context` 中注入 persistent memory 上下文。
+- [ ] 3.5 更新 AGENTS.md / CLAUDE.md 中的 auto-memory 指令（参考 Claude Code）。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行 artifact checker。
+- [ ] 4.5 手动验证：两个 session 之间记忆持久化。
+
+- [ ] 4.5 跑通至少一个 benchmark smoke，验证变更不影响 agent 执行正确性。
+
+## 5. PR 收尾
+
+- [ ] 5.1 归档到 `openspec/changes/archive/YYYY-MM-DD-add-persistent-cross-session-memory/`。
+- [ ] 5.2 从 backlog 移除。
+- [ ] 5.3 确认 Impact Analysis 无残留未知项。
+- [ ] 5.4 运行全量校验。

--- a/openspec/changes/add-semantic-code-search/design.md
+++ b/openspec/changes/add-semantic-code-search/design.md
@@ -1,0 +1,146 @@
+## Context
+
+语法级搜索（Grep、SymbolSearch）依赖精确的符号名或正则表达式。对于"修改所有类似的错误处理模式"这类任务，agent 需要先构想正则，再反复调整。语义搜索让 agent 用自然语言描述意图即可找到相关代码。
+
+## Decisions
+
+### 1. Embedding 模型选择
+
+默认使用 `all-MiniLM-L6-v2`（sentence-transformers）：
+- 开源、本地运行、无需 GPU。
+- 384 维向量，内存/磁盘开销小。
+- 虽然不是 code-specific 模型，但对自然语言描述找代码的效果可接受。
+
+可通过配置切换为 code-specific 模型（如 `jina-embeddings-v2-base-code`），配置路径：`config.code_intelligence.embedding_model`。
+
+### 2. 索引存储
+
+方案对比：
+
+| 方案 | 优点 | 缺点 |
+|------|------|------|
+| `sqlite-vec` | 零依赖（SQLite 扩展）、纯本地、和现有 sqlite 使用一致 | 较新、生态不如 ChromaDB |
+| `ChromaDB` | 成熟、Python 原生 | 额外进程依赖、重 |
+| `faiss-cpu` | Facebook 出品、高性能 | 无元数据存储、需自己搭 |
+
+选择 **`sqlite-vec`**：
+- 零额外服务进程，启动成本低。
+- 嵌入已有的 sqlite 使用模式（项目已在 LSP 和其他地方用 sqlite）。
+- `sqlite-vec` 支持 SIMD 加速的向量搜索。
+
+### 3. 索引内容
+
+索引单元 = 函数/方法级别的代码片段。使用 tree-sitter 将每个函数切分为独立的 chunk：
+
+```python
+@dataclass
+class CodeChunk:
+    file_path: str
+    function_name: str
+    start_line: int
+    end_line: int
+    code_text: str
+    embedding: list[float] | None  # lazy computed
+```
+
+索引粒度选择函数/方法级而非文件级或行级：
+- 文件级太粗：一个 500 行的文件匹配到不知道具体位置。
+- 行级太细：单行代码缺乏足够语义。
+- 函数级刚好：自包含语义单元，搜索结果可直接定位。
+
+### 4. 构建策略
+
+两种触发方式：
+
+1. **随 RepoMap 构建（配置开关）**：`RepoMap` 生成时可选同步生成 embedding 索引。通过 `config.code_intelligence.enable_embedding_index: bool` 控制。
+2. **懒构建（默认）**：首次调用 `SearchSimilar` 时触发，遍历仓库提取函数并生成 embedding。
+
+初始采用懒构建策略，避免 RepoMap 生成变慢。
+
+### 5. 增量更新
+
+`SearchSimilar` 执行时：
+1. 检查已索引文件的 mtime，失效已修改文件的旧条目。
+2. 扫描新增文件，补充索引。
+3. 仅对新/修改文件重新 embedding。
+
+不主动监控文件变更——依赖搜索时的被动探测。
+
+### 6. SearchSimilar 工具设计
+
+```
+SearchSimilar(query: str, top_n: int = 5) -> str
+```
+
+- `query`：自然语言描述或代码片段
+- `top_n`：返回结果数（默认 5）
+- 返回：每行 `file_path:start_line-end_line: function_name — relevance_score`
+
+工具能力：`WORKSPACE_READ` / `LOW` risk。
+
+### 7. 降级行为
+
+- sentence-transformers 未安装 → `SearchSimilar` 注册但不工作，返回明确的 "embedding 模型不可用" 错误。
+- 索引构建超时（>60s）→ 只索引已完成的文件，返回部分结果 + 警告。
+- 空仓库或无可提取函数 → 返回 "无可用索引"。
+
+## Goals / Non-Goals
+
+- 不支持跨仓库语义搜索。
+- 不支持自然语言生成代码（仅搜索已有代码）。
+- 不支持代码变更的语义 diff。
+- 不支持图片或多模态 embedding。
+- 不做分布式或远程索引。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 的语义搜索是如何实现的？
+2. 开源 embedding 模型对代码的语义理解效果如何？
+3. sqlite-vec vs ChromaDB 的选择？
+
+- findings:
+
+- Claude Code 没有公开其语义搜索实现细节，但其 `Grep` 工具的描述暗示主要依赖正则搜索而非语义搜索。Cursor 和 Copilot 使用 embedding-based 代码搜索作为核心体验。
+- `all-MiniLM-L6-v2` 在自然语言→代码的语义匹配上效果中等（比 code-specific 模型差 10-20%），但胜在轻量、本地、零成本。随着项目发展可升级模型。
+- `sqlite-vec` v0.0.1 已稳定，支持余弦相似度、欧氏距离搜索，Python binding 完善。ChromaDB 功能更全但引入了客户端-服务端架构开销。
+- Aider 使用 tree-sitter 将代码分割为函数级 chunks 并做 embedding 索引，其 `repo_map.py` 支持 `--map-tokens` 参数控制 token 预算——这与本 change 的索引粒度一致。
+
+- design impact:
+
+- 采用 sqlite-vec 以保持轻量和零服务依赖。
+- 函数级 chunk 与 Aider 的实践一致，提供可解释的搜索结果。
+- 懒构建策略避免 RepoMap 的性能回退。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| code_intelligence 模块 | 新增 embedding 和 index 子模块 |
+| RepoMap | 可选集成索引构建，默认不影响 |
+| 工具系统 | 新增 SearchSimilar 工具 |
+| pyproject.toml | 新增 sentence-transformers、sqlite-vec 依赖 |
+| 首次启动 | 懒构建可能耗时（大仓库几十秒），需有进度提示 |
+| MCP / benchmark / workspace safety | 不影响 |
+
+
+## Risks / Trade-offs
+
+- [Risk] 首次懒构建在大型仓库可能耗时数分钟。Mitigation: 构建过程输出进度提示，超时后返回部分结果。
+- [Risk] embedding 模型依赖 `sentence-transformers` 包，增加安装成本。Mitigation: 标记为可选依赖，模型不可用时工具明确报错而非崩溃。
+- [Risk] 函数级 chunk 对 C/Go 的非面向对象代码切分效果差。Mitigation: 对无法切分的文件降级为文件级 chunk。
+
+## Testing Strategy
+
+- embedding 生成测试：Python 函数生成 384 维向量。
+- sqlite-vec 索引测试：创建/查询/更新/增量失效。
+- SearchSimilar 工具测试：自然语言查询、代码片段查询。
+- 降级测试：模型不可用、空仓库、超时。
+- 懒构建性能测试：中等仓库 < 60s。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/add-semantic-code-search/proposal.md
+++ b/openspec/changes/add-semantic-code-search/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+当前代码智能工具（`RepoMap`、`SymbolSearch`、Grep、LSP 符号系列）全部是语法/结构级的。缺少基于语义的相似代码搜索能力。
+
+Claude Code、Cursor、Copilot 均支持 embedding-based 语义搜索，让 agent 能问"这里有没有类似这段错误处理的代码"、"找一下和这个函数签名相似的所有实现"。语法级搜索（Grep 按正则）无法捕捉意图相似性。
+
+该能力补齐后，code-intelligence 域从 "语法级" 扩展到 "语法级 + 语义级"，是 coding agent 代码理解能力的自然升级。
+
+## What Changes
+
+- 新增 `agent/code_intelligence/embeddings.py`：基于 sentence-transformers 的代码 embedding 生成器（默认 `all-MiniLM-L6-v2`，可配置为 code-specific 模型）。
+- 新增 `agent/code_intelligence/index.py`：基于 `sqlite-vec` 或 `ChromaDB` 的本地 embedding 索引，存储文件路径 + 代码片段 + embedding 向量。
+- 新增 `SearchSimilar` 工具：输入自然语言查询或代码片段，返回语义最相似的 Top-N 文件位置和代码片段。
+- 索引构建：作为 `RepoMap` 生成流程的扩展步骤（可选，通过配置开关），或首次调用 `SearchSimilar` 时懒构建。
+- 增量更新：文件修改后失效该文件对应的索引条目，下次搜索时增量重建。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `code-intelligence`: 新增 embedding 生成、向量索引和 `SearchSimilar` 语义搜索工具。
+
+## Impact
+
+- 影响代码：
+  - `agent/code_intelligence/embeddings.py`（新增）
+  - `agent/code_intelligence/index.py`（新增）
+  - `agent/tools/builtin/code_intelligence.py`（新增 SearchSimilar）
+  - `agent/code_intelligence/repo_map.py`（扩展：集成索引构建）
+  - `pyproject.toml`（新增依赖：sentence-transformers 或 chromadb）
+- 影响测试：
+  - `tests/agent/code_intelligence/test_embeddings.py`
+  - `tests/agent/code_intelligence/test_index.py`
+  - `tests/agent/tools/test_code_intelligence.py`
+- 不影响：现有搜索工具、workspace safety、AgentLoop。
+
+## Change Type
+
+- primary: feature

--- a/openspec/changes/add-semantic-code-search/specs/code-intelligence/spec.md
+++ b/openspec/changes/add-semantic-code-search/specs/code-intelligence/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: 语义代码搜索
+
+系统 SHALL 支持基于 embedding 向量的语义代码搜索。`SearchSimilar` 工具 SHALL 接受自然语言查询或代码片段，返回语义最相似的文件位置和代码片段，按相似度降序排列。
+
+#### Scenario: 自然语言查询
+
+- **GIVEN** 代码索引已构建且包含多个函数
+- **WHEN** agent 调用 SearchSimilar(query="查找所有处理超时错误的代码")
+- **THEN** 系统 SHALL 返回 Top-N 个语义最相关的函数
+- **AND** 每个返回值 SHALL 包含 file_path、行号范围、函数名和相似度分数
+
+#### Scenario: 代码片段查询
+
+- **GIVEN** 代码索引包含相似模式的代码
+- **WHEN** agent 调用 SearchSimilar 传入一段错误处理代码片段
+- **THEN** 系统 SHALL 返回代码库中语义相似的错误处理代码
+
+#### Scenario: 索引不存在时懒构建
+
+- **GIVEN** 当前仓库尚未构建 embedding 索引
+- **WHEN** agent 首次调用 SearchSimilar
+- **THEN** 系统 SHALL 自动触发索引构建
+- **AND** 构建完成后 SHALL 返回搜索结果
+
+#### Scenario: embedding 模型不可用
+
+- **GIVEN** sentence-transformers 库不可用或模型下载失败
+- **WHEN** agent 调用 SearchSimilar
+- **THEN** 系统 SHALL 返回明确错误："embedding 模型不可用"
+
+#### Scenario: 空仓库
+
+- **GIVEN** 仓库中无 Python/TS/JS/Go/Rust/Java 函数可提取
+- **WHEN** agent 调用 SearchSimilar
+- **THEN** 系统 SHALL 返回"无可用索引"提示
+
+### Requirement: 代码片段索引
+
+系统 SHALL 使用 tree-sitter 将代码按函数/方法级粒度切分为独立的 chunk 进行索引。每个 chunk SHALL 包含文件路径、函数名、行号范围和代码文本。索引存储 SHALL 基于 sqlite-vec。
+
+#### Scenario: 索引构建
+
+- **GIVEN** 仓库包含 50 个 Python 文件、每个文件有 5 个函数
+- **WHEN** 触发索引构建
+- **THEN** 系统 SHALL 提取约 250 个函数 chunk
+- **AND** 每个 chunk SHALL 生成 embedding 向量
+- **AND** SHALL 存入 sqlite-vec 索引
+
+#### Scenario: 增量更新
+
+- **GIVEN** 索引已构建
+- **AND** 其中一个文件自上次索引后被修改
+- **WHEN** 再次调用 SearchSimilar
+- **THEN** 修改的文件对应的旧条目 SHALL 被失效
+- **AND** 修改文件的当前版本 SHALL 被重新索引

--- a/openspec/changes/add-semantic-code-search/tasks.md
+++ b/openspec/changes/add-semantic-code-search/tasks.md
@@ -1,0 +1,46 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `code-intelligence` spec delta：定义语义搜索能力、embedding 模型、索引存储和 SearchSimilar 工具。
+- [ ] 1.2 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.3 维护 `## Impact Analysis`。
+- [ ] 1.4 维护 `## Reference Implementation Research`。
+
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+
+## 2. 测试
+
+- [ ] 2.1 embedding 生成测试：Python 函数生成 384 维向量。
+- [ ] 2.2 索引测试：创建/查询/更新 sqlite-vec 索引。
+- [ ] 2.3 SearchSimilar 工具测试：自然语言查询返回相关函数。
+- [ ] 2.4 code chunk 提取测试：tree-sitter 正确提取函数级 chunk。
+- [ ] 2.5 增量更新测试：修改文件后旧索引失效、新文件被索引。
+- [ ] 2.6 降级测试：sentence-transformers 不可用时返回明确错误。
+- [ ] 2.7 降级测试：空仓库返回"无可用索引"。
+- [ ] 2.8 懒构建性能测试：中等仓库（100+ 函数）构建时间 < 60s。
+
+## 3. 实现
+
+- [ ] 3.1 实现 `agent/code_intelligence/embeddings.py` —— embedding 模型加载和编码。
+- [ ] 3.2 实现 `agent/code_intelligence/index.py` —— sqlite-vec 索引创建和查询。
+- [ ] 3.3 实现 tree-sitter 函数级 chunk 提取（复用现有 tree-sitter 符号提取）。
+- [ ] 3.4 在 `code_intelligence.py` 新增 `SearchSimilar` 工具。
+- [ ] 3.5 接入 factory.py，注册 SearchSimilar 到 coding tool registry。
+- [ ] 3.6 更新 `pyproject.toml`：添加 sentence-transformers 和 sqlite-vec 依赖。
+- [ ] 3.7 配置项：`config.code_intelligence.embedding_model` 和 `enable_embedding_index`。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行 artifact checker。
+- [ ] 4.5 手动验证：用一个已知代码片段搜索，验证结果相关性。
+
+- [ ] 4.5 跑通至少一个 benchmark smoke，验证变更不影响 agent 执行正确性。
+
+## 5. PR 收尾
+
+- [ ] 5.1 归档到 `openspec/changes/archive/YYYY-MM-DD-add-semantic-code-search/`。
+- [ ] 5.2 从 backlog 移除。
+- [ ] 5.3 确认 Impact Analysis 无残留未知项。
+- [ ] 5.4 运行全量校验。

--- a/openspec/changes/improve-agent-execution-foundation/design.md
+++ b/openspec/changes/improve-agent-execution-foundation/design.md
@@ -1,0 +1,122 @@
+## Context
+
+两个子能力共享一个主题：让 agent 在 build mode 执行期更有自我感知——知道自己做到哪了（todo 追踪），失败了能自己恢复（错误重试）。
+
+## Decisions
+
+### 1. TodoWrite 工具设计
+
+数据模型复用 `Planning State` 的 `PlanItem`：
+
+```python
+class TodoItem:
+    id: str          # 稳定标识
+    content: str     # 任务描述
+    status: str      # pending | in_progress | completed
+    notes: str | None  # 可选说明
+```
+
+工具操作：
+
+- `create(content: str) -> TodoItem` — 创建新 todo
+- `update(id: str, status: str, notes: str | None) -> TodoItem` — 更新状态
+- `list(status: str | None) -> list[TodoItem]` — 列出所有或按状态过滤
+
+工具能力标记：`AGENT_STATE` / `MEDIUM` risk。
+
+与 Plan Mode 的 Planning State 关系：
+- Plan Mode 下 `UpdatePlan` 产出的是 *计划*（plan item），`TodoWrite` 操作的是 *执行状态*（execution todo）。
+- 两者使用相同的 item 数据模型但存储分开。Plan items 按 plan document 章节组织；execution todos 是扁平列表。
+- Build mode 下 `UpdatePlan` 不可用，只能用 `TodoWrite`。
+
+### 2. AgentLoop 注入 todo 上下文
+
+`_messages_with_run_context()` 在当前 todo 列表非空时，在系统消息末尾注入：
+
+```
+## Current Progress
+- [ ] 找到所有需要修改的文件
+- [in_progress] 实现 Edit 工具的替换逻辑
+- [completed] 阅读现有 tool registry 代码
+```
+
+只展示最近 10 条，按创建时间排序，completed 项在末尾。
+
+### 3. RetryHook 接入
+
+`RetryHook` 已有实现（`agent/hooks/builtin/retry.py`），核心逻辑：
+
+- `max_attempts = 3`
+- 退避：1s / 2s / 4s
+- 可重试错误分类基于工具返回的错误字符串：
+  - 匹配 `timeout|timed out|connection|rate limit|429|503|temporary` → 重试
+  - 匹配 `permission denied|not found|invalid|no such file` → 不重试
+- 重试时 trace 记录 `tool_retry` step
+
+接入方式：AgentLoop 在 `after_tool_execute` 中检查 `result` 是否为错误字符串，匹配可重试模式时，循环重试直到成功或达到最大次数。
+
+不通过 Hook 协议接入——Hook 协议是 fire-and-forget 回调形式，不返回"是否恢复"信号。改为直接在 AgentLoop 工具执行路径中内联重试逻辑，保留 RetryHook 类作为重试策略的配置载体。
+
+### 4. 重试与 approval 的交互
+
+如果第一次工具调用触发了 approval 且用户拒绝，不重试（权限拒绝是确定性错误）。
+如果第一次工具调用被 auto-approve 后执行失败，重试不再次触发 approval（同一个 tool call 的首次执行已经过了 approval gate）。
+
+## Goals / Non-Goals
+
+- 不改变 Plan Mode 的 `UpdatePlan`/`ExitPlanMode` 语义。
+- 不支持 todo 的依赖关系（不引入 DAG）。
+- 不支持跨 session 持久化 todo 状态。
+- 不支持 Bash 命令的重试——命令可能有副作用，不应该静默重试。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 与主流 coding agent 对比后识别的基础能力差距，需调研行业参考实现以指导设计方案。
+
+- research questions:
+
+1. Claude Code 的 `TodoWrite` 工具如何设计？
+2. Claude Code 的工具重试策略如何？
+3. Codex 的 task tracking 机制如何？
+
+- findings:
+
+- Claude Code 的 `TodoWrite` 以 `todos: list[{content, status, activeForm}]` 为参数，一次调用全量替换。status 为 `pending/in_progress/completed`，需要两个描述字段（列表显示用 content，状态栏用 activeForm）。Asterwynd 采用更简单的单条目 CRUD 模型，减少每次调用的 token 开销。
+- Claude Code 的 tool error retry 在 framework 层不可见（由 SDK 处理）。Codex 有显式的 tool retry with backoff。Asterwynd 采取中间路线：在 AgentLoop 层做基于错误字符串分类的重试，避免 SDK 依赖但提供比 "只报错" 更好的体验。
+- Codex 的 task list 与 Claude Code 类似，也是全量替换模式。
+
+- design impact:
+
+- Todo 采用单条目 CRUD 而非全量替换，减少 LLM 每次需要重写整个列表的 token 开销。
+- 重试策略先从简单错误字符串匹配开始，后续可升级为结构化错误码。
+
+## Impact Analysis
+
+| 影响面 | 状态 |
+|--------|------|
+| AgentLoop 工具执行路径 | 新增 retry 循环，向后兼容 |
+| ToolRegistry | 新增 TodoWrite 注册，不影响现有工具 |
+| AgentLoop run context | 新增 todo 注入段，不影响现有注入 |
+| TUI/Web 展示 | 新增可选面板，不改变现有面板 |
+| Plan Mode | 不影响 UpdatePlan/ExitPlanMode |
+| Benchmark | 不影响 runner，但可改善 benchmark 任务通过率 |
+| MCP | 不影响 |
+
+
+## Risks / Trade-offs
+
+- [Risk] TodoWrite 与 UpdatePlan/ExitPlanMode 共享 PlanItem 数据模型，可能造成语义混淆。Mitigation: 两者存储完全隔离，工具在不同 mode 下独立注册。
+- [Risk] 错误字符串匹配的重试分类可能漏判或误判。Mitigation: 从保守的匹配模式开始，后续 benchmark 数据驱动调整。
+- [Risk] Bash 命令被排除在重试范围外，但某些只读 Bash（如 `cat`）理论上可重试。Mitigation: 先保守排除全部 Bash 命令，后续数据驱动调整。
+
+## Testing Strategy
+
+- TodoWrite 工具单元测试：create/update/list operation、status 合法性校验、duplicate id。
+- RetryHook 策略单元测试：可重试错误重试 3 次后失败、不可重试不触发、退避间隔。
+- AgentLoop 集成测试：工具失败后自动重试、重试成功继续执行、达到上限报错。
+- AgentLoop 集成测试：build mode 注入 todo、todo 为空不注入、retry 不重复审批。
+- TUI todo 面板单元测试：pending/in_progress/completed 展示。
+## Pre-Implementation Review
+
+待 `grill-with-docs` 执行后填写。

--- a/openspec/changes/improve-agent-execution-foundation/proposal.md
+++ b/openspec/changes/improve-agent-execution-foundation/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+当前 Asterwynd 在 build mode 执行期有两个基础缺陷：
+
+1. **无执行期任务追踪**：Plan Mode 产出 `Plan Document` 和 `Planning State`，但 build mode 下 agent 没有工具把自己的执行进度写成结构化 todo 状态。多步任务中 agent 容易遗落步骤，benchmark 中 `asterwynd-003-agentloop-trace` 的跨文件 trace 传播遗漏正是这个问题的典型症状。
+
+2. **工具调用失败无自动恢复**：`RetryHook`（`agent/hooks/builtin/retry.py`）已实现指数退避重试逻辑但从未接入 `AgentLoop`。工具调用失败后 agent 直接拿到错误字符串，无法自动重试，导致 benchmark 的 `tool_error` 失败类别中包含大量可重试的瞬时错误。
+
+Claude Code 的 `TodoWrite` 工具让 agent 在任意 mode 下维护 `pending/in_progress/completed` 状态的任务列表；Codex、Cursor 均有类似机制。Claude Code 和 Codex 的工具调用失败均有重试/降级策略。
+
+## What Changes
+
+### 执行期 Todo 追踪
+
+- 新增 `TodoWrite` 工具，提供 `create`/`update`/`list` 操作，task item 模型复用 `Planning State` 的 item 结构（id、content、status、notes）。
+- `TodoWrite` 在 build/read_only/plan mode 下均可用，不限于 plan mode。
+- AgentLoop 在 build mode 系统消息中注入当前 todo 状态摘要。
+- TUI 和 Web UI 展示当前 todo 列表面板。
+
+### 工具错误恢复
+
+- 将 `RetryHook` 接入 AgentLoop 的 HookManager。
+- 定义重试策略：最大 3 次重试、指数退避（1s/2s/4s）、仅对瞬时错误（timeout、connection、rate limit）重试。
+- 确定性错误（参数错误、权限拒绝、文件不存在）不重试。
+- 重试过程在 trace 中记录为独立 step。
+
+## Capabilities
+
+### New Capabilities
+
+- 无。在现有 `agent-runtime`、`tool-system`、`planning` 能力域内扩展。
+
+### Modified Capabilities
+
+- `tool-system`: 新增 `TodoWrite` 工具。
+- `agent-runtime`: `AgentLoop` 接入 `RetryHook`，定义可重试错误分类。
+- `planning`: `Planning State` item 模型被 `TodoWrite` 复用，build mode 下可展示执行进度。
+
+## Impact
+
+- 影响代码：
+  - `agent/tools/builtin/todo.py`（新增）
+  - `agent/tools/factory.py`
+  - `agent/loop.py`
+  - `agent/hooks/builtin/retry.py`
+  - `agent/tui/*.py`（todo 面板展示）
+  - `web/`（todo 面板展示）
+- 影响测试：
+  - `tests/agent/tools/test_todo_tool.py`
+  - `tests/agent/test_loop.py`
+  - `tests/agent/hooks/test_retry.py`
+  - `tests/agent/tui/`
+- 不影响：LLM provider 协议、workspace safety、benchmark runner、MCP 集成。
+
+## Change Type
+
+- primary: feature
+- secondary: refactor

--- a/openspec/changes/improve-agent-execution-foundation/specs/agent-runtime/spec.md
+++ b/openspec/changes/improve-agent-execution-foundation/specs/agent-runtime/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: 工具调用失败自动重试
+
+AgentLoop SHALL 在工具调用返回瞬时错误时自动重试。可重试错误 SHALL 匹配 `timeout|timed out|connection|rate limit|429|503|temporary` 模式。确定性错误（`permission denied|not found|invalid|no such file`）SHALL NOT 重试。
+
+#### Scenario: 瞬时错误自动重试
+
+- **GIVEN** 工具执行因 timeout 失败
+- **WHEN** AgentLoop 检测到错误匹配可重试模式
+- **THEN** AgentLoop SHALL 以指数退避间隔重试
+- **AND** 最大重试次数 SHALL 为 3
+
+#### Scenario: 重试成功
+
+- **GIVEN** 第一次执行因 rate limit 失败
+- **WHEN** 第二次重试成功
+- **THEN** AgentLoop SHALL 使用成功的工具结果继续执行
+
+#### Scenario: 确定性错误不重试
+
+- **GIVEN** 工具执行因 `permission denied` 失败
+- **WHEN** AgentLoop 检测到错误不匹配可重试模式
+- **THEN** AgentLoop SHALL NOT 重试
+- **AND** 错误结果直接返回给 LLM
+
+#### Scenario: 重试次数耗尽
+
+- **GIVEN** 工具执行连续 3 次因 timeout 失败
+- **WHEN** 第 3 次重试也失败
+- **THEN** AgentLoop SHALL 记录 `tool_error` trace step
+- **AND** 最后一次错误结果返回给 LLM
+
+#### Scenario: 重试不重复触发审批
+
+- **GIVEN** 第一次工具执行已通过 approval gate
+- **WHEN** 后续重试执行
+- **THEN** AgentLoop SHALL NOT 再次触发 approval handler
+
+### Requirement: build mode 注入执行期 todo 状态
+
+AgentLoop SHALL 在 build mode 且存在非空 todo 列表时向系统消息注入当前 todo 状态摘要。
+
+#### Scenario: todo 列表非空时注入
+
+- **GIVEN** AgentMode 为 BUILD
+- **AND** TodoWrite 工具维护了 3 个 todo item
+- **WHEN** 构建系统消息
+- **THEN** 系统消息 SHALL 包含 `## Current Progress` 段
+- **AND** 段内 SHALL 按 status 分组展示
+
+#### Scenario: todo 列表为空时不注入
+
+- **GIVEN** AgentMode 为 BUILD
+- **AND** todo 列表为空
+- **WHEN** 构建系统消息
+- **THEN** 系统消息 SHALL NOT 包含 `## Current Progress` 段

--- a/openspec/changes/improve-agent-execution-foundation/specs/planning/spec.md
+++ b/openspec/changes/improve-agent-execution-foundation/specs/planning/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: build mode 执行进度展示
+
+系统 SHALL 支持在 build mode 和 read_only mode 下通过 `TodoWrite` 工具维护执行期 todo 列表。TodoWrite 维护的 todo list SHALL 与 Plan Mode 的 Planning State 共享相同的 item 数据模型（id, content, status, notes），但 SHALL 存储为独立的扁平列表，不按 plan document 章节组织。
+
+#### Scenario: build mode 下创建 todo
+
+- **GIVEN** AgentMode 为 BUILD
+- **AND** Plan Mode 未产出 Planning State
+- **WHEN** agent 通过 TodoWrite 创建 todo item
+- **THEN** item SHALL 正常创建
+- **AND** TUI/Web UI SHALL 可展示当前 todo 列表
+
+#### Scenario: TodoWrite 与 Planning State 隔离
+
+- **GIVEN** Plan Mode 产出了 2 个 plan items
+- **WHEN** agent 切换到 build mode 后通过 TodoWrite 创建 1 个 execution todo
+- **THEN** plan items SHALL 保持不变
+- **AND** execution todo SHALL 独立维护
+- **AND** 两者不影响对方的展示

--- a/openspec/changes/improve-agent-execution-foundation/specs/tool-system/spec.md
+++ b/openspec/changes/improve-agent-execution-foundation/specs/tool-system/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: TodoWrite 工具
+
+系统 SHALL 提供 `TodoWrite` 工具，用于在任意 Agent Mode 下维护结构化的执行期任务列表。TodoWrite SHALL 支持 `create`、`update` 和 `list` 操作。每个 todo item SHALL 包含 id、content、status 和可选的 notes 字段。
+
+#### Scenario: 创建新任务
+
+- **GIVEN** 当前 todo 列表为空
+- **WHEN** agent 调用 TodoWrite `create` 且 content 为 "实现 Edit 工具"
+- **THEN** 系统 SHALL 返回新创建的 todo item
+- **AND** item SHALL 有唯一 id
+- **AND** item.status SHALL 为 `pending`
+
+#### Scenario: 更新任务状态
+
+- **GIVEN** 存在一个 status 为 `pending` 的 todo item
+- **WHEN** agent 调用 TodoWrite `update` 且 status 为 `in_progress`
+- **THEN** 该 item 的 status SHALL 变为 `in_progress`
+
+#### Scenario: 列出所有任务
+
+- **GIVEN** 存在 3 个 todo item
+- **WHEN** agent 调用 TodoWrite `list` 且不传 status 过滤
+- **THEN** 系统 SHALL 返回全部 3 个 item
+
+#### Scenario: 按状态过滤
+
+- **GIVEN** 存在 2 个 `pending` 和 1 个 `completed` item
+- **WHEN** agent 调用 TodoWrite `list` 且 status 为 `pending`
+- **THEN** 系统 SHALL 仅返回 2 个 `pending` item
+
+#### Scenario: 无效 status 被拒绝
+
+- **GIVEN** 任意状态
+- **WHEN** agent 调用 TodoWrite `update` 且 status 为 `unknown`
+- **THEN** 系统 SHALL 返回错误，item 保持不变

--- a/openspec/changes/improve-agent-execution-foundation/tasks.md
+++ b/openspec/changes/improve-agent-execution-foundation/tasks.md
@@ -1,0 +1,43 @@
+## 1. 规格
+
+- [ ] 1.1 更新 `tool-system` spec delta：定义 TodoWrite 工具行为。
+- [ ] 1.2 更新 `agent-runtime` spec delta：定义工具错误重试行为和可重试错误分类。
+- [ ] 1.3 更新 `planning` spec delta：定义 build mode 下的执行期 todo 状态展示。
+- [ ] 1.4 开发前使用 `grill-with-docs` 审视 `design.md`。
+- [ ] 1.5 维护 `## Impact Analysis`。
+- [ ] 1.6
+- [ ] 1.7 同步 spec delta 到 `openspec/specs/<capability>/spec.md`（当前规格）。
+ 维护 `## Reference Implementation Research`。
+
+## 2. 测试
+
+- [ ] 2.1 TodoWrite 工具单元测试：create/update/list、无效 status、重复 id。
+- [ ] 2.2 RetryHook 策略测试：可重试错误重试 3 次后失败、不可重试错误直接失败、退避间隔。
+- [ ] 2.3 AgentLoop 集成测试：工具失败后自动重试、重试成功继续执行、达到最大次数后上报 error。
+- [ ] 2.4 AgentLoop 集成测试：build mode 下注入 todo 上下文、todo 列表空时不注入。
+- [ ] 2.5 Loop 集成测试：retry 不重复触发 approval。
+- [ ] 2.6 TUI test：todo 面板展示 pending/in_progress/completed 项。
+
+## 3. 实现
+
+- [ ] 3.1 实现 `agent/tools/builtin/todo.py` —— TodoWrite 工具。
+- [ ] 3.2 在 `factory.py` 注册 TodoWrite 到所有 mode 的 tool registry。
+- [ ] 3.3 在 AgentLoop `_execute_tool_calls` 中接入重试逻辑。
+- [ ] 3.4 在 `_messages_with_run_context` 中注入 todo 状态。
+- [ ] 3.5 在 TUI 中新增可选 todo 面板。
+- [ ] 3.6 Web UI 展示 todo 状态（后续 PR 或本 PR 内，视复杂度）。
+
+## 4. 验证
+
+- [ ] 4.1 运行相关单元/集成测试。
+- [ ] 4.2 运行全量测试 `uv run pytest -q`。
+- [ ] 4.3 运行 `npx --yes @fission-ai/openspec@1.4.1 validate --all --strict`。
+- [ ] 4.4 运行 `uv run python scripts/check_openspec_artifacts.py`。
+- [ ] 4.5 跑通至少一个 benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前，将本 change 归档到 `openspec/changes/archive/YYYY-MM-DD-improve-agent-execution-foundation/`。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除本 change。
+- [ ] 5.3 确认 Impact Analysis 无残留 `unknown`/`TBD`/`待确认`。
+- [ ] 5.4 运行全量校验。


### PR DESCRIPTION
## Summary

基于与 Claude Code、Codex、Cursor、Aider 等主流 coding agent 的系统性对比，识别 Asterwynd 当前必备基础能力的核心缺口，拆分为 6 个 OpenSpec change 规划文档：

| Change | 内容 | 优先级 |
|--------|------|--------|
| `improve-agent-execution-foundation` | todo 追踪 + 工具错误恢复重试 | P0 第一批 |
| `add-parallel-tool-execution` | AgentLoop 并行工具执行 | P0 第二批 |
| `add-persistent-cross-session-memory` | 跨 session 持久记忆 | P1 第一批 |
| `add-semantic-code-search` | embedding 语义代码搜索 | P1 第一批 |
| `add-multimodal-input-support` | 图片/多模态输入 | P2 第三批 |
| `add-background-task-execution-and-session-persistence` | 后台任务 + 会话持久化 | P2 第三批 |

每个 change 包含 proposal、design、tasks 和 spec delta。Backlog 更新按新增的第六批分组和依赖关系组织。

## Verification

- OpenSpec strict validate: 28/28 passed
- Artifact checker: passed
- 纯文档，无代码变更

## Test plan

- [x] CI: OpenSpec validate + artifact checker
- [ ] 人工 review 每个 change 的 scope 和 design 合理性

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>