### PR TITLE
归档已覆盖 change：context-builder / compression / system-prompt

### DIFF
--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/README.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/README.md
@@ -1,0 +1,3 @@
+# add-context-builder-architecture
+
+增加统一 ContextBuilder 架构

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/design.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/design.md
@@ -1,0 +1,70 @@
+## Context
+
+上下文来源正在增长：system prompt、AGENTS.md、memory、skills、plan/todo、未来自动召回和压缩摘要。继续在 `AgentLoop._messages_with_run_context()` 内串行拼接会让优先级、预算、裁剪和 trace 变得不可维护。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 定义 `ContextSource` contract。
+- 定义 `ContextBuilder` 的注册、排序、预算、裁剪和渲染流程。
+- 将现有 memory index、skill context、plan/todo 迁移到 source adapter。
+- 为 AGENTS.md 和自动召回预留 source 类型。
+- 输出可测试的 build report。
+
+**Non-Goals:**
+
+- 不重写 AgentLoop。
+- 不改变 memory、skill、planning 的业务数据结构。
+- 不在本 change 中实现向量检索或智能压缩。
+- 不把 ContextBuilder 暴露成用户可直接操作的工具。
+
+## Decisions
+
+### Decision 1: Source 自描述优先级和预算
+
+每个 ContextSource 声明 id、priority、budget、trim policy、render 方法和 metadata。
+
+理由：新增来源时不需要继续修改中心方法的拼接顺序。
+
+### Decision 2: Builder 输出 messages 和 build report
+
+ContextBuilder 返回最终 message 列表或 context fragments，同时返回来源、token 估算、裁剪和错误信息。
+
+理由：上下文构建问题需要可观测性；测试也可以断言 report 而非解析长文本。
+
+### Decision 3: 裁剪只发生在允许裁剪的来源
+
+system prompt 和硬性规则默认不可裁剪；memory index、skill list、plan/todo 等低优先级来源可按策略裁剪。
+
+理由：预算压力下应保护行为边界和当前用户意图。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - propose 阶段确认 ContextBuilder 是后续上下文能力的中枢。
+  - 初始 source 列表覆盖现有 `_messages_with_run_context()` 的全部动态内容。
+- Options considered:
+  - 继续维护 AgentLoop 内拼接。
+  - 只提取几个 helper 函数。
+  - 建立 ContextSource/ContextBuilder 抽象。
+- Rejected alternatives:
+  - 继续拼接无法支撑后续自动召回和预算治理。
+  - helper 函数不能表达跨来源优先级和统一 report。
+- Final confirmations:
+  - 开发前必须确认 source priority、默认预算、build report schema 和迁移顺序。
+- Remaining risks:
+  - 抽象过重会拖慢交付；实现应先覆盖现有来源，避免预建复杂插件系统。
+
+## Risks / Trade-offs
+
+- [Risk] 迁移后 prompt 行为出现隐性变化。Mitigation: 增加 before/after message 构造回归测试。
+- [Risk] token 估算不准。Mitigation: 将估算作为预算近似，并记录实际 provider 限制错误。
+- [Risk] 来源之间重复内容。Mitigation: source id 和 report 支持定位重复注入。
+
+## Testing Strategy
+
+- 单元测试覆盖 source 排序、预算分配、裁剪和不可裁剪来源。
+- 集成测试覆盖 memory、skills、plan/todo 同时存在时的 message 构造。
+- 回归测试覆盖空来源、异常来源和超预算来源。
+- Trace/report 测试覆盖来源 id、token 估算和裁剪原因。

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/proposal.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+当前 `AgentLoop._messages_with_run_context()` 直接拼接 memory index、skill index、active skill、plan mode、plan 和 todos。新增上下文来源时必须继续修改同一个方法，优先级、预算和可观测性也缺少统一模型。
+
+本 change 引入统一 ContextBuilder，作为 system prompt、AGENTS.md、记忆、skill、plan/todo 等上下文来源的注册、排序、预算和渲染中枢。
+
+## Change Type
+
+- primary: feature
+- secondary: [refactor]
+
+## What Changes
+
+- 新增 `ContextBuilder` 和 `ContextSource` 抽象。
+- 上下文来源 SHALL 声明优先级、默认 token 预算、是否可裁剪、渲染方式和 trace metadata。
+- ContextBuilder SHALL 按优先级构建最终 message/context，并在总预算不足时裁剪低优先级来源。
+- 初始来源包括 system prompt、AGENTS.md Always 段、持久记忆索引、自动召回记忆、AGENTS.md Auto-Attached 段、活跃 skill、plan/todo。
+- 构建结果 SHALL 暴露来源清单、token 估算和裁剪原因。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: AgentLoop 使用统一上下文构建路径。
+- `memory-context`: 记忆索引和召回结果成为 ContextSource。
+- `skills`: skill index 和 active skill context 成为 ContextSource。
+- `planning`: plan/todo 状态成为低优先级运行上下文来源。
+
+## Dependencies
+
+- 承接 `add-agents-runtime-instruction-injection` 和 `improve-system-prompt-architecture` 的输出。
+- 后续 `add-automatic-memory-recall` 依赖本 change 提供可控注入位置。
+- 后续 `add-context-compression-strategies` 复用 token 预算和裁剪信息。
+
+## Impact Analysis
+
+- 影响代码：
+  - 新增 `agent/context/`。
+  - `agent/loop.py` 将 ad-hoc 拼接迁移为 ContextBuilder。
+  - `agent/memory/persistent.py`、skill runtime、planning state 暴露 ContextSource adapter。
+- 影响测试：
+  - 来源排序和预算分配单元测试。
+  - AgentLoop message 构造回归测试。
+  - 记忆、skill、plan 同时存在时的集成测试。
+- 不影响：
+  - 不改变各来源的业务语义。
+  - 不在本 change 中实现向量召回或智能记忆更新。
+  - 不把 ContextBuilder 设计成独立 agent loop。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 上下文构建是 coding agent 核心路径，应参考 Claude Code、Aider、SWE-agent 等项目对分层上下文和预算控制的取舍。
+- research questions:
+  - 成熟工具如何组织 system、repo rules、memory、repo map、tool results 和 conversation history？
+  - token 预算不足时哪些来源优先保留？
+  - 构建结果如何记录到 trace，便于调试上下文污染和缺失？
+- findings:
+  - `/tmp/research-to-propose.md` 已记录初步调研：Claude Code 使用分层注入，Aider 强调结构化 repo map 和摘要优先。
+  - 开发前必须补实本仓库当前 `_messages_with_run_context()` 的迁移清单和参考实现发现。
+- design impact:
+  - 本 proposal 把 ContextBuilder 定位为多个后续 change 的基础设施，要求清晰的来源接口和可观测性。

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/agent-runtime/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/agent-runtime/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: AgentLoop 使用 ContextBuilder 构建运行上下文
+
+AgentLoop SHALL 使用 ContextBuilder 统一注册、排序、预算、裁剪和渲染运行上下文来源。
+
+#### Scenario: 构建包含多个来源的上下文
+
+- **GIVEN** system prompt、memory index、active skill 和 plan state 同时存在
+- **WHEN** AgentLoop 构建模型消息
+- **THEN** 系统 SHALL 通过 ContextBuilder 按优先级生成最终上下文
+- **AND** 返回上下文构建报告
+
+### Requirement: ContextBuilder 生成构建报告
+
+ContextBuilder SHALL 记录每个 ContextSource 的 id、优先级、预算、token 估算、裁剪状态和渲染结果状态。
+
+#### Scenario: 低优先级来源被裁剪
+
+- **GIVEN** 总上下文超过预算
+- **WHEN** ContextBuilder 裁剪低优先级来源
+- **THEN** 构建报告 SHALL 记录被裁剪来源和原因

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/memory-context/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/memory-context/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: 记忆上下文作为 ContextSource
+
+持久记忆索引和自动召回记忆 SHALL 通过 ContextSource adapter 注入运行上下文。
+
+#### Scenario: 记忆索引可用
+
+- **GIVEN** 当前项目存在持久记忆索引
+- **WHEN** ContextBuilder 构建上下文
+- **THEN** 记忆 adapter SHALL 按预算渲染记忆索引或召回结果

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/planning/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/planning/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Plan 和 Todo 状态作为 ContextSource
+
+当前 plan、todo 和 plan mode 状态 SHALL 通过 ContextSource adapter 注入运行上下文，并在预算不足时允许裁剪。
+
+#### Scenario: 当前存在计划状态
+
+- **GIVEN** AgentLoop 中存在 plan 或 todo 状态
+- **WHEN** ContextBuilder 构建上下文
+- **THEN** planning adapter SHALL 渲染当前计划状态

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/skills/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/specs/skills/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Skill 上下文作为 ContextSource
+
+Skill index 和 active skill context SHALL 通过 ContextSource adapter 注入运行上下文。
+
+#### Scenario: 已激活 skill
+
+- **GIVEN** 当前运行已有 active skill
+- **WHEN** ContextBuilder 构建上下文
+- **THEN** skill adapter SHALL 渲染 active skill 指令
+- **AND** 构建报告 SHALL 记录该来源

--- a/openspec/changes/archive/2026-07-12-add-context-builder-architecture/tasks.md
+++ b/openspec/changes/archive/2026-07-12-add-context-builder-architecture/tasks.md
@@ -1,0 +1,35 @@
+## 1. 规格
+
+- [ ] 1.1 修改 `agent-runtime` spec delta，定义 ContextBuilder 和 ContextSource contract。
+- [ ] 1.2 修改 `memory-context`、`skills`、`planning` spec delta，定义对应 ContextSource adapter。
+- [ ] 1.3 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.4 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，确认 source priority、预算和 build report schema。
+- [ ] 1.5 开发前补实 `## Reference Implementation Research`。
+
+## 2. 测试
+
+- [ ] 2.1 新增 ContextSource 排序和预算分配测试。
+- [ ] 2.2 新增可裁剪/不可裁剪来源测试。
+- [ ] 2.3 新增 AgentLoop message 构造回归测试。
+- [ ] 2.4 新增 build report 和 trace metadata 测试。
+
+## 3. 实现
+
+- [ ] 3.1 新增 `agent/context/`。
+- [ ] 3.2 将 `_messages_with_run_context()` 迁移到 ContextBuilder。
+- [ ] 3.3 为 memory、skills、plan/todo 增加 source adapter。
+- [ ] 3.4 输出 build report 并接入 trace。
+
+## 4. 验证
+
+- [ ] 4.1 运行 context、AgentLoop、memory、skills、planning 相关测试。
+- [ ] 4.2 运行全量测试。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行项目 OpenSpec artifact checker。
+- [ ] 4.5 跑通至少一个 AgentLoop benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前归档本 change。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change。
+- [ ] 5.3 确认 Impact Analysis 和 Reference Implementation Research 已更新为最终结论。

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/README.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/README.md
@@ -1,0 +1,3 @@
+# add-context-compression-strategies
+
+增加上下文压缩多策略

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/design.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/design.md
@@ -1,0 +1,71 @@
+## Context
+
+会话历史压缩当前主要依赖 LLM 摘要，缺少无 LLM 降级和硬预算保证。随着工具调用、图片输入、长任务和自动上下文来源增多，压缩策略必须明确保护哪些内容、可以丢弃哪些内容，以及失败时如何降级。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 抽象 Summarizer interface。
+- 提供 LLM、truncation、sliding window 三类策略。
+- 保证压缩结果满足硬预算或返回明确失败。
+- 保留工具调用链完整性和最近用户意图。
+- 提供 `compact_context` 主动压缩工具。
+
+**Non-Goals:**
+
+- 不把压缩摘要自动写入长期记忆。
+- 不在本 change 中实现语义记忆召回。
+- 不改变 tool-call 消息链合法性要求。
+- 不引入 provider 专属压缩 API 依赖。
+
+## Decisions
+
+### Decision 1: Summarizer 返回结构化结果
+
+结果包含压缩后 messages、summary、dropped_ranges、token_estimate、strategy 和 warnings。
+
+理由：AgentLoop 和 trace 需要理解压缩影响，而不是只拿到一段文本。
+
+### Decision 2: 工具调用链作为不可拆分单元
+
+压缩时 tool call 与 tool result 必须一起保留、一起摘要或一起移除，不能产生不合法消息链。
+
+理由：协议合法性是最高优先级约束。
+
+### Decision 3: LLM 不可用时使用确定性降级
+
+Truncation 和 SlidingWindow 不依赖模型，用于 provider 不可用、测试和低成本模式。
+
+理由：压缩能力不能完全依赖 LLM。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - propose 阶段确认多策略和硬预算是核心目标。
+  - `compact_context` 属于本 change 范围。
+- Options considered:
+  - 只优化现有 LLM 摘要 prompt。
+  - 增加一个简单截断 fallback。
+  - 引入可插拔 Summarizer 抽象。
+- Rejected alternatives:
+  - 只改 prompt 不能解决无 LLM 和硬预算问题。
+  - 单一 fallback 难以覆盖不同运行模式。
+- Final confirmations:
+  - 开发前必须确认工具调用链保留规则、预算估算来源、工具权限和压缩触发条件。
+- Remaining risks:
+  - 压缩摘要可能丢失隐含决策；需要用回归场景覆盖长任务关键事实。
+
+## Risks / Trade-offs
+
+- [Risk] 过度压缩导致 agent 忘记约束。Mitigation: system、AGENTS Always 和当前用户消息不可被低优先级策略删除。
+- [Risk] `compact_context` 被频繁调用增加成本。Mitigation: 工具实现限流或基于预算触发。
+- [Risk] 摘要幻觉。Mitigation: LLM 摘要 prompt 要求只总结已出现事实，并保留来源范围。
+
+## Testing Strategy
+
+- Summarizer contract 测试覆盖三类策略。
+- 测试 tool call/result 配对在压缩后仍合法。
+- 无 LLM 模式测试覆盖确定性输出。
+- Agent 主动调用 `compact_context` 的工具测试。
+- 超预算输入测试覆盖硬预算成功和明确失败路径。

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/proposal.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+当前 `MemoryManager.compact()` 只有 LLM 摘要一种主要策略；无 LLM 时会丢弃中间消息，且缺少滑动窗口、优先级保留和硬 token 上限。长任务中这会导致上下文不可控、工具链断裂或关键信息丢失。
+
+本 change 引入可插拔上下文压缩策略，让系统在不同模型、预算和运行模式下都能有明确降级行为。
+
+## Change Type
+
+- primary: feature
+- secondary: [refactor]
+
+## What Changes
+
+- 新增 Summarizer 抽象，支持 LLM 摘要、纯截断和滑动窗口策略。
+- 压缩策略 SHALL 保留 system message、完整工具调用链、最近用户意图和关键运行状态。
+- 压缩结果 SHALL 满足硬 token 预算；无法满足时返回明确错误或采用更强降级策略。
+- 新增 `compact_context` 工具，让 agent 可以主动请求压缩当前上下文。
+- 压缩过程 SHALL 记录策略、输入规模、输出规模和被丢弃范围。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `memory-context`: 会话内记忆支持多策略压缩和硬预算。
+- `coding-tools`: 新增 agent 主动压缩上下文的工具能力。
+
+## Dependencies
+
+- 建议在 `add-context-builder-architecture` 后实现，以复用统一 token 预算和来源 metadata。
+
+## Impact Analysis
+
+- 影响代码：
+  - `agent/memory/manager.py` 抽离压缩策略。
+  - 新增 `agent/memory/summarizers/`。
+  - 新增或扩展内置工具注册 `compact_context`。
+- 影响测试：
+  - 各 summarizer 策略单元测试。
+  - 工具调用链完整性回归测试。
+  - 无 LLM 降级和硬预算测试。
+- 不影响：
+  - 不改变持久记忆文件格式。
+  - 不在本 change 中实现语义记忆召回。
+  - 不把压缩摘要写入长期记忆，除非用户或后续 change 明确要求。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: 长上下文压缩已有 SWE-agent、Aider 等参考实现，需借鉴其 summarizer 抽象、降级策略和工具链保留规则。
+- research questions:
+  - SWE-agent 如何封装不同 summarizer，并在预算不足时触发？
+  - Aider 的轻量 ChatSummary 如何保留编辑和文件上下文？
+  - tool call / tool result 的配对完整性如何在压缩中保证？
+- findings:
+  - `/tmp/research-to-propose.md` 已记录初步调研：SWE-agent 使用可插拔 Summarizer，Aider 使用轻量聊天摘要。
+  - 开发前必须结合当前 Message 模型和 tool-call 协议补实具体迁移风险。
+- design impact:
+  - 本 proposal 要求策略抽象和硬预算，而不是只优化现有 LLM 摘要 prompt。

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/specs/coding-tools/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/specs/coding-tools/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Agent 可主动请求上下文压缩
+
+系统 SHALL 提供 `compact_context` 工具，允许 agent 在长任务中主动请求压缩当前会话上下文。
+
+#### Scenario: Agent 调用 compact_context
+
+- **GIVEN** 当前上下文接近预算上限
+- **WHEN** agent 调用 `compact_context`
+- **THEN** 系统 SHALL 执行配置的压缩策略
+- **AND** 返回压缩报告

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/specs/memory-context/spec.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/specs/memory-context/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: 会话上下文支持多策略压缩
+
+MemoryManager SHALL 支持可插拔 Summarizer 策略，包括 LLM 摘要、确定性截断和滑动窗口。
+
+#### Scenario: LLM 不可用时压缩上下文
+
+- **GIVEN** 当前 provider 不可用于摘要
+- **WHEN** 系统需要压缩会话上下文
+- **THEN** MemoryManager SHALL 使用确定性降级策略
+
+### Requirement: 压缩结果满足硬 token 预算
+
+上下文压缩 SHALL 生成不超过目标 token 预算的结果，或返回明确失败状态。
+
+#### Scenario: 输入历史超过预算
+
+- **GIVEN** 会话历史超过目标 token 预算
+- **WHEN** 压缩策略执行成功
+- **THEN** 输出上下文 SHALL 不超过目标预算
+
+### Requirement: 压缩保持工具消息链合法
+
+压缩策略 SHALL 保持 tool call 与 tool result 的配对合法性，不得产生违反 provider 协议的消息链。
+
+#### Scenario: 历史中包含工具调用
+
+- **GIVEN** 会话历史包含 tool call 和对应 tool result
+- **WHEN** 压缩策略裁剪历史
+- **THEN** 系统 SHALL 一起保留、摘要或移除配对消息

--- a/openspec/changes/archive/2026-07-12-add-context-compression-strategies/tasks.md
+++ b/openspec/changes/archive/2026-07-12-add-context-compression-strategies/tasks.md
@@ -1,0 +1,35 @@
+## 1. 规格
+
+- [ ] 1.1 修改 `memory-context` spec delta，定义多策略压缩和硬预算。
+- [ ] 1.2 修改 `coding-tools` spec delta，定义 `compact_context` 工具。
+- [ ] 1.3 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.4 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，确认压缩触发、工具调用链保留和预算策略。
+- [ ] 1.5 开发前补实 `## Reference Implementation Research`。
+
+## 2. 测试
+
+- [ ] 2.1 新增 LLM、truncation、sliding window summarizer 测试。
+- [ ] 2.2 新增 tool call/result 配对合法性测试。
+- [ ] 2.3 新增无 LLM 降级和硬预算测试。
+- [ ] 2.4 新增 `compact_context` 工具测试。
+
+## 3. 实现
+
+- [ ] 3.1 新增 Summarizer 抽象和三类策略。
+- [ ] 3.2 改造 `MemoryManager.compact()` 使用策略接口。
+- [ ] 3.3 增加 `compact_context` 内置工具。
+- [ ] 3.4 记录压缩 report 和 trace metadata。
+
+## 4. 验证
+
+- [ ] 4.1 运行 memory/context 和 tool 相关测试。
+- [ ] 4.2 运行全量测试。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行项目 OpenSpec artifact checker。
+- [ ] 4.5 跑通长上下文 benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前归档本 change。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change。
+- [ ] 5.3 确认 Impact Analysis 和 Reference Implementation Research 已更新为最终结论。

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/README.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/README.md
@@ -1,0 +1,3 @@
+# improve-system-prompt-architecture
+
+优化系统提示词架构

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/design.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/design.md
@@ -1,0 +1,70 @@
+## Context
+
+默认 prompt 目前分散在 CLI、Web session、AgentLoop 和 role registry 附近，且内容过于通用。Asterwynd 需要把 coding-agent 身份、工具协议、编辑约束和验证责任变成统一、可测试、可演进的提示词资产。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 提供统一 system prompt builder。
+- 明确 coding agent 身份、能力边界、工具使用、工作区安全、编辑规则和验证责任。
+- CLI、Web 和角色 agent 使用同一基础 prompt。
+- 支持将技术栈版本和运行模式作为结构化变量注入。
+- 保留角色 prompt 的增量扩展能力。
+
+**Non-Goals:**
+
+- 不在 prompt 中复制所有项目文档。
+- 不改变 LLM provider 协议。
+- 不用 prompt 取代工具权限和 workspace safety 代码约束。
+- 不在本 change 中实现 AGENTS.md 加载。
+
+## Decisions
+
+### Decision 1: Prompt builder 输出结构化段落
+
+Prompt builder 以命名段落组织硬性规则、身份、工具协议、编辑约束、验证清单和动态变量，而不是拼接散乱字符串。
+
+理由：便于测试关键段落是否存在，也便于 ContextBuilder 后续作为最高优先级来源处理。
+
+### Decision 2: 基础 prompt 与角色 prompt 合成
+
+角色注册只提供角色差异，基础 coding-agent 约束始终由统一 builder 注入。
+
+理由：保证 subagent 或 role agent 不会绕开核心约束。
+
+### Decision 3: Prompt 只描述行为边界，不承载动态事实库
+
+技术栈版本可以作为短变量注入，但长期项目知识、AGENTS.md、memory、skills 由对应 ContextSource 注入。
+
+理由：避免 system prompt 膨胀和事实过期。
+
+## Pre-Implementation Review
+
+- Questions resolved:
+  - propose 阶段确认首要目标是统一 prompt 构造路径，而非单点文案优化。
+  - 约束、示例和结束清单都属于目标范围。
+- Options considered:
+  - 只替换现有两句中文 prompt。
+  - 为 CLI/Web 分别维护 prompt。
+  - 引入统一 prompt builder。
+- Rejected alternatives:
+  - 单点替换无法解决入口漂移。
+  - 分入口维护会重复制造不一致。
+- Final confirmations:
+  - 开发前必须确认 prompt 段落顺序、动态变量来源、角色合成方式和测试断言粒度。
+- Remaining risks:
+  - Prompt 过长会挤占任务上下文；开发时应保持基础 prompt 精炼，并把动态内容交给 ContextBuilder。
+
+## Risks / Trade-offs
+
+- [Risk] 约束写进 prompt 后被误认为替代代码安全检查。Mitigation: 文档明确 prompt 是行为引导，权限仍由 runtime enforce。
+- [Risk] 多入口迁移遗漏。Mitigation: 测试覆盖 CLI、Web 和 role registry。
+- [Risk] 动态版本信息过期。Mitigation: 从配置或单一常量来源生成。
+
+## Testing Strategy
+
+- 单元测试覆盖 prompt builder 段落顺序和关键约束存在性。
+- 集成测试覆盖 CLI/Web 构造 AgentLoop 时使用同一基础 prompt。
+- 角色 prompt 测试覆盖基础约束 + 角色差异的合成。
+- 快照或黄金文本测试只覆盖稳定片段，避免脆弱全文断言。

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/proposal.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+当前默认 system prompt 只有非常弱的通用助手描述，无法表达 Asterwynd 的 coding-agent 身份、工具协议、代码修改边界、验证责任和项目技术栈。CLI、Web、角色注册各自拼接 prompt，也容易产生行为漂移。
+
+本 change 将 system prompt 升级为可维护的结构化提示词架构，作为运行时上下文的最高优先级层。
+
+## Change Type
+
+- primary: feature
+- secondary: [refactor]
+
+## What Changes
+
+- 定义统一的 coding-agent system prompt 模板，覆盖身份、能力边界、工具调用协议、工作区安全、编辑约束和验证责任。
+- 将负面约束和硬性规则前置，降低模型忽略关键约束的概率。
+- 将项目技术栈、版本和入口约束以可维护方式注入，避免硬编码散落在 CLI/Web/role registry。
+- 对关键行为提供短示例和执行前/结束前自查清单。
+- CLI、Web session 和 AgentLoop SHALL 复用同一 prompt 构造路径。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `agent-runtime`: 统一 system prompt 构造和注入语义。
+- `cli`: CLI 运行使用统一 system prompt。
+- `web-ui`: Web session 使用统一 system prompt。
+
+## Dependencies
+
+- 与 `add-agents-runtime-instruction-injection` 共享高优先级上下文边界。
+- 建议在 `add-context-builder-architecture` 之前或同批落地，后者负责把 system prompt 纳入统一排序和预算。
+
+## Impact Analysis
+
+- 影响代码：
+  - `agent/main.py` 和 `web/session.py` 不再各自硬编码默认 prompt。
+  - `agent/loop.py` 的 system message 构造改为调用统一 prompt builder。
+  - `agent/workflow/role_registry.py` 的角色 prompt 与统一基础 prompt 合成。
+- 影响测试：
+  - CLI/Web 构造 AgentLoop 时的 system prompt 一致性测试。
+  - 角色 prompt 合成测试。
+  - 关键约束存在性和重复注入回归测试。
+- 不影响：
+  - 不改变模型 provider API。
+  - 不在本 change 中实现 AGENTS.md 解析。
+  - 不在 prompt 中硬编码所有长期项目知识。
+
+## Reference Implementation Research
+
+- status: enabled
+- reason: system prompt 是 coding agent 行为边界的关键资产，应参考 Cursor、Aider、Claude Code 对约束、示例和编辑协议的组织方式。
+- research questions:
+  - 成熟 coding agent 如何分离基础身份 prompt、项目规则和角色 prompt？
+  - 编辑协议、工具协议和安全约束应放在 prompt 的哪个位置？
+  - 哪些内容适合静态模板，哪些应由 ContextBuilder 动态注入？
+- findings:
+  - `/tmp/research-to-propose.md` 已记录初步调研：Cursor rules 强调约束和示例，Aider 对 edit format 使用示例驱动。
+  - 开发前必须补充当前代码基线下的 prompt 拼接路径调研，避免 CLI/Web/role registry 行为不一致。
+- design impact:
+  - 本 proposal 将 prompt 构造作为独立架构面，而不是简单改写两句硬编码字符串。

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/agent-runtime/spec.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/agent-runtime/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: 统一 system prompt 构造
+
+系统 SHALL 使用统一 prompt builder 构造 coding-agent system prompt，并在 AgentLoop 中作为最高优先级上下文使用。
+
+#### Scenario: AgentLoop 创建默认运行
+
+- **GIVEN** 用户未提供自定义 system prompt
+- **WHEN** AgentLoop 初始化运行消息
+- **THEN** 系统 SHALL 使用统一 prompt builder 生成 system prompt
+
+### Requirement: System prompt 表达 coding-agent 行为边界
+
+system prompt SHALL 明确定义 coding-agent 身份、工具调用协议、工作区安全、编辑约束和验证责任。
+
+#### Scenario: 检查默认 system prompt
+
+- **GIVEN** 系统生成默认 system prompt
+- **WHEN** 测试读取 prompt 段落
+- **THEN** prompt SHALL 包含工具调用、代码编辑和验证责任相关约束

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/cli/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: CLI 使用统一 system prompt
+
+CLI SHALL 通过统一 prompt builder 构造默认 system prompt，不得维护独立漂移的硬编码 prompt。
+
+#### Scenario: CLI 启动 AgentLoop
+
+- **GIVEN** 用户通过 CLI 启动任务
+- **WHEN** CLI 创建 AgentLoop
+- **THEN** CLI SHALL 使用统一 prompt builder 的输出作为默认 system prompt

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/web-ui/spec.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/specs/web-ui/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Web session 使用统一 system prompt
+
+Web session SHALL 通过统一 prompt builder 构造默认 system prompt，与 CLI 保持同一基础行为边界。
+
+#### Scenario: Web 创建新会话
+
+- **GIVEN** 用户在 Web UI 创建新会话
+- **WHEN** server 初始化 session runtime
+- **THEN** Web session SHALL 使用统一 prompt builder 的输出作为默认 system prompt

--- a/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/tasks.md
+++ b/openspec/changes/archive/2026-07-12-improve-system-prompt-architecture/tasks.md
@@ -1,0 +1,36 @@
+## 1. 规格
+
+- [ ] 1.1 修改 `agent-runtime` spec delta，定义统一 system prompt builder。
+- [ ] 1.2 修改 `cli` 和 `web-ui` spec delta，定义入口复用统一 prompt。
+- [ ] 1.3 同步对应 current spec 到 `openspec/specs/<capability>/spec.md`。
+- [ ] 1.4 开发前使用 `grill-with-docs` 或等价设计追问审视 `design.md`，确认段落顺序、动态变量和角色合成方式。
+- [ ] 1.5 开发前补实 `## Reference Implementation Research`。
+
+## 2. 测试
+
+- [ ] 2.1 新增 prompt builder 单元测试。
+- [ ] 2.2 新增 CLI/Web system prompt 一致性测试。
+- [ ] 2.3 新增 role prompt 合成测试。
+- [ ] 2.4 新增关键约束存在性和重复注入回归测试。
+
+## 3. 实现
+
+- [ ] 3.1 新增统一 prompt builder。
+- [ ] 3.2 迁移 CLI prompt 构造路径。
+- [ ] 3.3 迁移 Web session prompt 构造路径。
+- [ ] 3.4 迁移 role registry 的基础约束合成。
+
+## 4. 验证
+
+- [ ] 4.1 运行 prompt、CLI、Web session 相关测试。
+- [ ] 4.2 运行全量测试。
+- [ ] 4.3 运行 OpenSpec strict validate。
+- [ ] 4.4 运行项目 OpenSpec artifact checker。
+- [ ] 4.5 跑通 CLI 和 Web smoke。
+- [ ] 4.6 跑通至少一个 AgentLoop benchmark smoke。
+
+## 5. PR 收尾
+
+- [ ] 5.1 PR 发起前归档本 change。
+- [ ] 5.2 从 `docs/openspec-change-backlog.md` 移除或更新本 change。
+- [ ] 5.3 确认 Impact Analysis 和 Reference Implementation Research 已更新为最终结论。


### PR DESCRIPTION
## 概要

归档 3 个已被 `implement-context-injection-pipeline` (PR #59) 完整覆盖的 change：

- `add-context-builder-architecture` → ContextBuilder 管线已实现
- `add-context-compression-strategies` → Summarizer 协议已实现
- `improve-system-prompt-architecture` → 三段式 system prompt 已统一

## 验证

- [x] OpenSpec validate --all: 26/26 passed

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)