### PR TITLE
快速修复：压缩阈值 + 延迟百分位 + Java/Kotlin tree-sitter 语法支持

### DIFF
--- a/agent/code_intelligence/tree_sitter_symbols.py
+++ b/agent/code_intelligence/tree_sitter_symbols.py
@@ -43,6 +43,18 @@ def _load_rust_language() -> Language:
     return Language(tree_sitter_rust.language())
 
 
+def _load_java_language() -> Language:
+    import tree_sitter_java
+
+    return Language(tree_sitter_java.language())
+
+
+def _load_kotlin_language() -> Language:
+    import tree_sitter_kotlin
+
+    return Language(tree_sitter_kotlin.language())
+
+
 JAVASCRIPT_QUERY = """
 (function_declaration name: (identifier) @function.name)
 (class_declaration name: (identifier) @class.name)
@@ -89,6 +101,20 @@ RUST_QUERY = """
 (trait_item name: (type_identifier) @trait.name)
 """
 
+JAVA_QUERY = """
+(class_declaration name: (identifier) @class.name)
+(interface_declaration name: (identifier) @interface.name)
+(method_declaration name: (identifier) @method.name)
+(constructor_declaration name: (identifier) @constructor.name)
+(enum_declaration name: (identifier) @enum.name)
+"""
+
+KOTLIN_QUERY = """
+(class_declaration name: (identifier) @class.name)
+(object_declaration name: (identifier) @object.name)
+(function_declaration name: (identifier) @function.name)
+"""
+
 
 DEFAULT_TREE_SITTER_REGISTRY: dict[str, TreeSitterLanguage] = {
     "javascript": TreeSitterLanguage(
@@ -116,6 +142,18 @@ DEFAULT_TREE_SITTER_REGISTRY: dict[str, TreeSitterLanguage] = {
         source="tree-sitter-rust",
         load_language=_load_rust_language,
         query=RUST_QUERY,
+    ),
+    "java": TreeSitterLanguage(
+        language="java",
+        source="tree-sitter-java",
+        load_language=_load_java_language,
+        query=JAVA_QUERY,
+    ),
+    "kotlin": TreeSitterLanguage(
+        language="kotlin",
+        source="tree-sitter-kotlin",
+        load_language=_load_kotlin_language,
+        query=KOTLIN_QUERY,
     ),
 }
 
@@ -210,6 +248,17 @@ def _extract_symbols(
                     symbol_kind = "method"
                     name = f"{owner}.{name}"
                 elif kind == "method" and (owner := _rust_trait_owner(node, text)):
+                    name = f"{owner}.{name}"
+            elif registration.language == "java":
+                if kind in {"method", "constructor"} and (
+                    owner := _java_method_owner(node, text)
+                ):
+                    name = f"{owner}.{name}"
+            elif registration.language == "kotlin":
+                if kind == "function" and (
+                    owner := _kotlin_class_owner(node, text)
+                ):
+                    symbol_kind = "method"
                     name = f"{owner}.{name}"
 
             line = node.start_point[0] + 1
@@ -314,6 +363,16 @@ def _go_method_owner(node, text: str) -> str | None:
     return None
 
 
+def _java_method_owner(node, text: str) -> str | None:
+    if class_node := _ancestor(node, "class_declaration"):
+        return _child_text(class_node, "name", text)
+    if interface_node := _ancestor(node, "interface_declaration"):
+        return _child_text(interface_node, "name", text)
+    if enum_node := _ancestor(node, "enum_declaration"):
+        return _child_text(enum_node, "name", text)
+    return None
+
+
 def _rust_impl_owner(node, text: str) -> str | None:
     if impl_node := _ancestor(node, "impl_item"):
         return _child_text(impl_node, "type", text)
@@ -323,4 +382,12 @@ def _rust_impl_owner(node, text: str) -> str | None:
 def _rust_trait_owner(node, text: str) -> str | None:
     if trait_node := _ancestor(node, "trait_item"):
         return _child_text(trait_node, "name", text)
+    return None
+
+
+def _kotlin_class_owner(node, text: str) -> str | None:
+    if class_node := _ancestor(node, "class_declaration"):
+        return _child_text(class_node, "name", text)
+    if object_node := _ancestor(node, "object_declaration"):
+        return _child_text(object_node, "name", text)
     return None

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -56,6 +56,7 @@ class MemoryManager:
         llm: Optional["LLM"] = None,
         summarizer: Optional["Summarizer"] = None,
         compaction_gap: int = 5,
+        compact_trigger_tokens: int | None = None,
     ):
         self.messages: list["Message"] = []
         self.max_tokens = max_tokens
@@ -63,6 +64,7 @@ class MemoryManager:
         self.llm = llm
         self._summarizer = summarizer
         self._compaction_gap = compaction_gap
+        self.compact_trigger_tokens = compact_trigger_tokens
         self._last_compaction_iteration: int = -compaction_gap  # allow first
 
     # ------------------------------------------------------------------
@@ -95,18 +97,20 @@ class MemoryManager:
         messages: Optional[list["Message"]] = None,
         iteration: int = 0,
     ) -> bool:
-        """Trigger compaction when token count reaches 90% of budget.
+        """Trigger compaction when token count reaches the threshold.
 
-        Minimum *compaction_gap* iterations must pass between compactions
-        to avoid thrashing.
+        The threshold is `compact_trigger_tokens` if configured, otherwise
+        defaults to ``max_tokens - 15_000`` (reserving 15K tokens for the LLM
+        response).  Minimum *compaction_gap* iterations must pass between
+        compactions to avoid thrashing.
         """
         msgs = messages if messages is not None else self.messages
         total = self.count_tokens(msgs)
-        threshold = int(self.max_tokens * 0.9)
+        threshold = self.compact_trigger_tokens if self.compact_trigger_tokens is not None else max(1, self.max_tokens - 15_000)
         if total >= threshold:
             if iteration - self._last_compaction_iteration >= self._compaction_gap:
                 logger.info(
-                    "[Memory] %d tokens >= %d (90%% of %d budget), compacting",
+                    "[Memory] %d tokens >= %d (threshold, %d max budget), compacting",
                     total, threshold, self.max_tokens,
                 )
                 await self.compact(msgs)
@@ -115,9 +119,10 @@ class MemoryManager:
             else:
                 logger.info(
                     "[Memory] %d tokens >= %d but compaction skipped "
-                    "(last compaction at iteration %d, gap=%d)",
+                    "(last compaction at iteration %d, gap=%d, max budget=%d)",
                     total, threshold,
                     self._last_compaction_iteration, self._compaction_gap,
+                    self.max_tokens,
                 )
         return False
 

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -73,6 +73,30 @@ def build_summary(runs: list[tuple[str, dict[str, dict]]]) -> str:
         row = [name] + [str(s.get(k, 0)) for k in RESULT_ORDER] + [str(total)]
         lines.append("| " + " | ".join(row) + " |")
 
+    # Latency percentiles
+    lines.append("")
+    lines.append("## Latency Percentiles")
+    lines.append("")
+    lat_header = ["Agent", "p50", "p95", "p99", "Max"]
+    lines.append("| " + " | ".join(lat_header) + " |")
+    lines.append("|" + "|".join(["------"] * len(lat_header)) + "|")
+    for name, results in runs:
+        durations = sorted(
+            r["duration_seconds"]
+            for r in results.values()
+            if isinstance(r.get("duration_seconds"), (int, float))
+        )
+        if durations:
+            n = len(durations)
+            p50 = durations[int(n * 0.50)]
+            p95 = durations[int(n * 0.95)]
+            p99 = durations[int(n * 0.99)]
+            max_d = durations[-1]
+            row = [name, f"{p50:.1f}s", f"{p95:.1f}s", f"{p99:.1f}s", f"{max_d:.1f}s"]
+        else:
+            row = [name, "-", "-", "-", "-"]
+        lines.append("| " + " | ".join(row) + " |")
+
     return "\n".join(lines) + "\n"
 
 
@@ -105,6 +129,23 @@ def build_html(runs: list[tuple[str, dict[str, dict]]]) -> str:
         cells += f"<td><strong>{total}</strong></td>"
         summary_rows += f"<tr>{cells}</tr>"
 
+    latency_rows = ""
+    for name, results in runs:
+        durations = sorted(
+            r["duration_seconds"]
+            for r in results.values()
+            if isinstance(r.get("duration_seconds"), (int, float))
+        )
+        if durations:
+            n = len(durations)
+            p50 = durations[int(n * 0.50)]
+            p95 = durations[int(n * 0.95)]
+            p99 = durations[int(n * 0.99)]
+            max_d = durations[-1]
+            latency_rows += f"<tr><td>{name}</td><td>{p50:.1f}s</td><td>{p95:.1f}s</td><td>{p99:.1f}s</td><td>{max_d:.1f}s</td></tr>"
+        else:
+            latency_rows += f"<tr><td>{name}</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>"
+
     return f"""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Cross-Agent Benchmark</title>
 <style>
@@ -130,6 +171,11 @@ small {{ color: #888; font-weight: normal; }}
 <table class="summary">
 <thead><tr><th>Agent</th>{"".join(f"<th>{k}</th>" for k in RESULT_ORDER)}<th>Total</th></tr></thead>
 <tbody>{summary_rows}</tbody>
+</table>
+<h2>Latency Percentiles</h2>
+<table>
+<thead><tr><th>Agent</th><th>p50</th><th>p95</th><th>p99</th><th>Max</th></tr></thead>
+<tbody>{latency_rows}</tbody>
 </table>
 </body></html>"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "tree-sitter-typescript>=0.23.2",
     "tree-sitter-go>=0.25.0",
     "tree-sitter-rust>=0.24.2",
+    "tree-sitter-java>=0.23.0",
+    "tree-sitter-kotlin>=1.0.0",
     "mcp>=1.28.1",
 ]
 

--- a/tests/agent/code_intelligence/test_tree_sitter_symbols.py
+++ b/tests/agent/code_intelligence/test_tree_sitter_symbols.py
@@ -102,17 +102,70 @@ def test_tree_sitter_keeps_file_entry_when_file_exceeds_configured_limit(tmp_pat
 
 
 def test_unregistered_source_language_keeps_file_entry_without_fake_symbols(tmp_path):
-    source = tmp_path / "Service.java"
-    source.write_text("class Service { void run() {} }\n", encoding="utf-8")
+    source = tmp_path / "stub.c"
+    source.write_text("int main(void) { return 0; }\n", encoding="utf-8")
 
     repo_map = build_repo_map(policy=WorkspacePolicy(tmp_path))
 
     summary = repo_map.files[0]
-    assert summary.path == "Service.java"
-    assert summary.language == "java"
+    assert summary.path == "stub.c"
+    assert summary.language == "c"
     assert summary.category == "source"
     assert summary.symbols == []
     assert summary.parse_error is None
+
+
+def test_tree_sitter_extracts_java_and_kotlin_symbols(tmp_path):
+    (tmp_path / "Service.java").write_text(
+        "class Service {\n"
+        "  void run() {}\n"
+        "  Service() {}\n"
+        "}\n"
+        "interface Port {\n"
+        "  void accept();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Main.kt").write_text(
+        "class Service {\n"
+        "  fun run() {}\n"
+        "}\n"
+        "interface Port {\n"
+        "  fun accept()\n"
+        "}\n"
+        "object Logger {\n"
+        "  fun log() {}\n"
+        "}\n"
+        "enum class State {\n"
+        "  READY\n"
+        "}\n"
+        "fun topLevel() {}\n",
+        encoding="utf-8",
+    )
+
+    repo_map = build_repo_map(policy=WorkspacePolicy(tmp_path))
+    symbols_by_path = {
+        entry.path: [(symbol.kind, symbol.name) for symbol in entry.symbols]
+        for entry in repo_map.files
+    }
+
+    assert symbols_by_path["Service.java"] == [
+        ("class", "Service"),
+        ("method", "Service.run"),
+        ("constructor", "Service.Service"),
+        ("interface", "Port"),
+        ("method", "Port.accept"),
+    ]
+    assert symbols_by_path["Main.kt"] == [
+        ("class", "Service"),
+        ("method", "Service.run"),
+        ("class", "Port"),
+        ("method", "Port.accept"),
+        ("object", "Logger"),
+        ("method", "Logger.log"),
+        ("class", "State"),
+        ("function", "topLevel"),
+    ]
 
 
 def test_tree_sitter_keeps_file_entry_when_grammar_is_unavailable(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-kotlin" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
     { name = "typer" },
@@ -224,7 +226,9 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-go", specifier = ">=0.25.0" },
+    { name = "tree-sitter-java", specifier = ">=0.23.0" },
     { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
+    { name = "tree-sitter-kotlin", specifier = ">=1.0.0" },
     { name = "tree-sitter-rust", specifier = ">=0.24.2" },
     { name = "tree-sitter-typescript", specifier = ">=0.23.2" },
     { name = "typer", specifier = ">=0.12.0" },
@@ -2756,6 +2760,21 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
+]
+
+[[package]]
 name = "tree-sitter-javascript"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2769,6 +2788,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
     { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
     { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-kotlin"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/bb/bdab3665eeca21246130eec79c76e42456cfa72d59606266ecdbf37f9a96/tree_sitter_kotlin-1.1.0.tar.gz", hash = "sha256:322a35bdae75e25ae64dae6027be609c5422fab282084117816c4ebcda6168da", size = 1095728, upload-time = "2025-01-09T19:02:18.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/a5/ce5a2ba7b97db8d90c89516674f5c46e2d41503e00dd743ba7aad4661097/tree_sitter_kotlin-1.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6cca5ef06d090e8494ac1d9f0aac71ed32207d412766b5df7da00d94334181a2", size = 312883, upload-time = "2025-01-09T19:02:02.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/20/66105b6e94d062440955d374e64d030c3173cf4f592f6a6a3c426b3c94d0/tree_sitter_kotlin-1.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:910b41a580dae00d319e555075f3886a41386d1067931b14c7de504eeae3ae2a", size = 337016, upload-time = "2025-01-09T19:02:04.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/4c/e1ef38fe412fa9851403fc75a653f2b69bbe1e11e2e7faf219631ebe7e4a/tree_sitter_kotlin-1.1.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:906e5444ebb01db439cb3ad65913598a4ea957b0e068aa973265926a17eb00e0", size = 359927, upload-time = "2025-01-09T19:02:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/65/bd/0f3aac45eb88b6b3173ac9c23bc41d8865943cbbe1caaafc001cd1b73c90/tree_sitter_kotlin-1.1.0-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a92afe24b634cf914c5812af0f5c53184b1c18bdf6ee5505c83afac81f6bf6c", size = 339269, upload-time = "2025-01-09T19:02:08.644Z" },
+    { url = "https://files.pythonhosted.org/packages/08/dc/4944abf3a8bc630262e93e0857bd7044d521995c1f6af50650e4fe1fdde0/tree_sitter_kotlin-1.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5960034a5c5bcc7ccb21dc7a29e4267ac4f0ef37884f39d75695eac7f004deff", size = 328921, upload-time = "2025-01-09T19:02:10.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c9/5cca0a44db41224f7f10992450af17ff432c1a336852efb312246d5705e5/tree_sitter_kotlin-1.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:d4d3f330f515ba8b91da04a5335eb9ff3ce071c7b7855958912f2560f6e14976", size = 315933, upload-time = "2025-01-09T19:02:12.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/b9/12fa97f63d2b7517c6f5d16938f0c5bfe84d925c652c75ff1c5e29bf6a44/tree_sitter_kotlin-1.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:e030f127a7d07952907adb9070248bd42fb86dc76fd92744727551b50e131ee7", size = 310414, upload-time = "2025-01-09T19:02:16.23Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述

Phase 1 面试差距修复：三个独立但相关的快速改进。

## 改动内容

### QW2: 压缩触发从比例阈值改为绝对 Token 阈值
- `agent/memory/manager.py`
- 将压缩触发条件从 `max_tokens * 0.9` 改为 `compact_trigger_tokens` 绝对值
- 默认值 `max(max_tokens - 15_000, 1)`，保留 15K token 供 LLM 响应
- 新增 `compact_trigger_tokens` 配置参数，支持显式覆盖
- 修复日志不再硬编码 "90%"

### QW3: Benchmark 延迟百分位
- `benchmarks/compare.py`
- MD/HTML 报告新增 Latency Percentiles 表
- 使用 nearest-rank 方法计算 p50/p95/p99
- 无数据时优雅降级为 "-"

### QW4: Java/Kotlin Tree-sitter 支持
- `agent/code_intelligence/tree_sitter_symbols.py`
- 新增 `tree-sitter-java`、`tree-sitter-kotlin` 依赖
- 支持类、接口、方法、构造器、枚举、对象的符号提取
- 实现 method ownership 解析（方法归属到所在类）
- 新增集成测试覆盖 Java 和 Kotlin

## 测试

```
47 passed (memory 41 + tree_sitter 6) — 全绿
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)