### PR TITLE
Phase 2: Token 追踪 + 增量压缩 + AskUserQuestion

### DIFF
--- a/agent/context/summarizer.py
+++ b/agent/context/summarizer.py
@@ -38,6 +38,14 @@ class Summarizer(Protocol):
         """
         ...
 
+    async def merge(self, previous: str, new_events: str, budget: int = 0) -> str | None:
+        """Merge a previous running summary with a new events summary.
+
+        Return the merged summary string, or ``None`` if merging is not
+        supported (the caller should fall back to concatenation).
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # LLMSummarizer
@@ -49,6 +57,14 @@ _LLM_SUMMARY_SYSTEM_PROMPT = (
     "Preserve every file path, function name, tool name, error message, "
     "unresolved question, and key decision. "
     "Output ONLY the four-section Markdown block described in the user prompt."
+)
+
+_MERGE_SYSTEM_PROMPT = (
+    "You are merging two conversation summaries for a coding agent. "
+    "Synthesize them into ONE coherent four-section Markdown summary "
+    "while preserving all critical context: every file path, function "
+    "name, tool name, error message, unresolved question, and key "
+    "decision must survive."
 )
 
 _LLM_SUMMARY_USER_TEMPLATE = """\
@@ -148,6 +164,36 @@ class LLMSummarizer:
 
         return (response.content or "").strip()
 
+    async def merge(self, previous: str, new_events: str, budget: int = 0) -> str | None:
+        """Merge a running summary with a new events summary via LLM."""
+        if not previous and not new_events:
+            return None
+
+        user_text = (
+            f"## Previous Summary\n\n{previous}\n\n"
+            f"## New Events Summary\n\n{new_events}"
+        )
+
+        budget_hint = (
+            f"\n\nKeep the merged summary under approximately {budget} tokens."
+            if budget > 0
+            else ""
+        )
+
+        try:
+            response = await self._llm.chat(
+                messages=[
+                    Message(role="system", content=_MERGE_SYSTEM_PROMPT),
+                    Message(role="user", content=user_text + budget_hint),
+                ],
+                tools=None,
+            )
+        except Exception:
+            logger.warning("LLMSummarizer: merge LLM call failed", exc_info=True)
+            return None
+
+        return (response.content or "").strip() or None
+
 
 # ---------------------------------------------------------------------------
 # TruncationSummarizer — no-LLM fallback
@@ -205,3 +251,7 @@ class TruncationSummarizer:
             )
             TruncationSummarizer._warned = True
         return _truncate_tool_outputs(messages, self._max_chars)
+
+    async def merge(self, previous: str, new_events: str, budget: int = 0) -> str | None:
+        """Return None — merge is not supported; the caller falls back to concatenation."""
+        return None

--- a/agent/cost_tracker.py
+++ b/agent/cost_tracker.py
@@ -12,7 +12,10 @@ MODEL_PRICES: dict[str, tuple[float, float]] = {
 
 
 def compute_cost(model: str, input_tokens: int, output_tokens: int) -> float | None:
-    for prefix, (in_price, out_price) in MODEL_PRICES.items():
+    # Sort by prefix length descending to avoid short-prefix collisions
+    # (e.g. "gpt-4o" matching "gpt-4o-mini" before the longer prefix).
+    for prefix in sorted(MODEL_PRICES, key=len, reverse=True):
+        in_price, out_price = MODEL_PRICES[prefix]
         if model.startswith(prefix):
             return (input_tokens / 1_000_000) * in_price + (output_tokens / 1_000_000) * out_price
     return None

--- a/agent/cost_tracker.py
+++ b/agent/cost_tracker.py
@@ -1,0 +1,26 @@
+MODEL_PRICES: dict[str, tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-5": (3.75, 15.00),
+    "claude-sonnet-4": (3.00, 15.00),
+    "claude-opus-4": (15.00, 75.00),
+    "claude-haiku-3.5": (0.80, 4.00),
+    "deepseek-chat": (0.27, 1.10),
+    "deepseek-reasoner": (0.55, 2.19),
+}
+# USD per 1M tokens (input, output)
+
+
+def compute_cost(model: str, input_tokens: int, output_tokens: int) -> float | None:
+    for prefix, (in_price, out_price) in MODEL_PRICES.items():
+        if model.startswith(prefix):
+            return (input_tokens / 1_000_000) * in_price + (output_tokens / 1_000_000) * out_price
+    return None
+
+
+def format_cost(cost: float | None) -> str:
+    if cost is None:
+        return "unknown"
+    if cost < 0.01:
+        return f"${cost:.6f}"
+    return f"${cost:.4f}"

--- a/agent/hooks/builtin/token_budget.py
+++ b/agent/hooks/builtin/token_budget.py
@@ -19,7 +19,13 @@ class TokenBudgetHook:
         self.total_tokens = 0
 
     async def after_llm_call(self, response: "LLMResponse") -> None:
-        pass
+        if response.usage:
+            self.total_tokens += response.usage.input_tokens + response.usage.output_tokens
+            ratio = self.total_tokens / self.budget if self.budget else 0
+            if ratio >= self.warn_threshold:
+                logger.warning(
+                    f"[TokenBudget] {self.total_tokens}/{self.budget} tokens ({ratio*100:.1f}%)"
+                )
 
     async def after_tool_execute(self, tool_call: ToolCall, result: str) -> None:
         estimated = len(result) // 4

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -14,6 +14,7 @@ from agent.approval import (
     build_approval_request,
     redact_value,
 )
+from agent.question import QuestionHandler
 from agent.message import Message, system_message, tool_result_message, extract_text
 from agent.result import RunResult, StopReason, ToolCallMade
 from agent.tools.base import ToolCall
@@ -79,6 +80,7 @@ class AgentLoop:
         tool_result_display: ToolResultDisplayConfig | None = None,
         skill_runtime: SkillRuntime | None = None,
         approval_handler: ApprovalHandler | None = None,
+        question_handler: "QuestionHandler | None" = None,
         mcp_manager: "McpManager | None" = None,
         background_manager: BackgroundTaskManager | None = None,
         session_store: SessionStore | None = None,
@@ -107,6 +109,7 @@ class AgentLoop:
         else:
             self.context_builder = self._make_default_context_builder()
         self.approval_handler = approval_handler or FailClosedApprovalHandler()
+        self._question_handler = question_handler
         self.mcp_manager = mcp_manager
         self.background_manager = background_manager
         self.session_store = session_store
@@ -118,6 +121,7 @@ class AgentLoop:
         self._subagent_tools_registered = False
         self._todo_tool_registered = False
         self._bg_tools_registered = False
+        self._question_tool_registered = False
         self._execution_todos: list[PlanItem] = []
         self._todo_next_id = 1
         self._iteration = 0
@@ -129,6 +133,7 @@ class AgentLoop:
             self._ensure_subagent_tools_registered()
         self._ensure_todo_tool_registered()
         self._ensure_background_task_tools_registered()
+        self._ensure_question_tool_registered()
         if self.skill_runtime is not None:
             self.tool_registry.register(ActivateSkillTool(self.skill_runtime))
 
@@ -286,6 +291,13 @@ class AgentLoop:
             trace_sink.record_plan_document(event_type, document)
         if event_sink:
             await event_sink(event_type, document)
+
+    def _ensure_question_tool_registered(self) -> None:
+        if self._question_tool_registered:
+            return
+        from agent.tools.builtin.ask_user import AskUserQuestionTool
+        self.tool_registry.register(AskUserQuestionTool(self._question_handler))
+        self._question_tool_registered = True
 
     def _ensure_plan_tools_registered(self) -> None:
         if self._plan_tools_registered:
@@ -474,6 +486,7 @@ class AgentLoop:
         resume_snapshot: SessionSnapshot | None = None,
     ) -> RunResult:
         tool_calls_made: list[ToolCallMade] = []
+        token_counters: dict[str, int] = {"input": 0, "output": 0}
         start_iteration = 0
 
         if resume_snapshot is not None:
@@ -551,6 +564,9 @@ class AgentLoop:
                 on_event=on_event,
             )
             await self.hooks.after_llm_call(response)
+            if response.usage:
+                token_counters["input"] += response.usage.input_tokens
+                token_counters["output"] += response.usage.output_tokens
             if trace_recorder:
                 trace_recorder.record_iteration(
                     iteration,
@@ -586,6 +602,9 @@ class AgentLoop:
                     content=response.content or "",
                     stop_reason=StopReason.END_TURN,
                     tool_calls_made=tool_calls_made,
+                    total_tokens=token_counters["input"] + token_counters["output"],
+                    input_tokens=token_counters["input"],
+                    output_tokens=token_counters["output"],
                 ))
                 if on_event:
                     await on_event("done", {
@@ -597,6 +616,9 @@ class AgentLoop:
                     content=response.content or "",
                     stop_reason=StopReason.END_TURN,
                     tool_calls_made=tool_calls_made,
+                    total_tokens=token_counters["input"] + token_counters["output"],
+                    input_tokens=token_counters["input"],
+                    output_tokens=token_counters["output"],
                 )
 
             # Bug 3: assistant 消息只追加一次（移到 for 循环之外）
@@ -814,6 +836,9 @@ class AgentLoop:
             content=final_content,
             stop_reason=StopReason.MAX_ITERATIONS,
             tool_calls_made=tool_calls_made,
+            total_tokens=token_counters["input"] + token_counters["output"],
+            input_tokens=token_counters["input"],
+            output_tokens=token_counters["output"],
         )
         await self.hooks.on_completion(result)
         if on_event:

--- a/agent/main.py
+++ b/agent/main.py
@@ -24,6 +24,7 @@ import typer
 load_dotenv()
 
 from agent.approval import ApprovalHandler, CliApprovalHandler
+from agent.question import FailClosedQuestionHandler as FailClosedQH, QuestionAnswer, Question
 from agent.loop import AgentLoop
 from agent.commands import CommandContext, build_default_slash_command_registry
 from agent.commands.init import write_aster_md
@@ -40,6 +41,7 @@ from agent.background import BackgroundTaskManager
 from agent.session import SessionSnapshot, SessionStore
 from agent.hooks.manager import HookManager
 from agent.hooks.builtin import LoggingHook, TracingHook
+from agent.hooks.builtin.token_budget import TokenBudgetHook
 from agent.memory.manager import MemoryManager
 from agent.memory.persistent import PersistentMemory
 from agent.llm import LLM
@@ -70,6 +72,23 @@ def _setup_logging() -> None:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
         handlers=handlers,
     )
+
+class CliQuestionHandler:
+    """CLI question handler using stdin/stdout."""
+
+    async def ask_question(self, question: Question) -> QuestionAnswer:
+        import sys
+
+        print(f"\n[Agent Question] {question.title}", file=sys.stderr)
+        print(question.body, file=sys.stderr)
+        if question.options:
+            for i, opt in enumerate(question.options, 1):
+                print(f"  {i}. {opt}", file=sys.stderr)
+            answer = input("Your answer (number or text): ").strip()
+        else:
+            answer = input("Your answer: ").strip()
+        return QuestionAnswer(question_id=question.question_id, answer=answer)
+
 
 app = typer.Typer()
 
@@ -223,6 +242,7 @@ def _build_agent_core(
     hooks = HookManager([
         LoggingHook(verbose=False),
         TracingHook(),
+        TokenBudgetHook(budget=80_000),
     ])
 
     memory = MemoryManager(max_tokens=80_000)
@@ -240,6 +260,12 @@ def _build_agent_core(
         sessions_root=_sessions_root(workspace_policy.workspace_root)
     )
 
+    # Determine question handler: use CLI handler when approval is interactive CLI
+    if isinstance(approval_handler, CliApprovalHandler) and approval_handler.interactive:
+        question_handler_instance = CliQuestionHandler()
+    else:
+        question_handler_instance = FailClosedQH()
+
     return AgentLoop(
         llm=llm,
         tool_registry=registry,
@@ -252,6 +278,7 @@ def _build_agent_core(
         tool_result_display=config.tools.display,
         skill_runtime=skill_runtime,
         approval_handler=approval_handler,
+        question_handler=question_handler_instance,
         mcp_manager=mcp_manager,
         background_manager=background_manager,
         session_store=session_store,

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -66,6 +66,8 @@ class MemoryManager:
         self._compaction_gap = compaction_gap
         self.compact_trigger_tokens = compact_trigger_tokens
         self._last_compaction_iteration: int = -compaction_gap  # allow first
+        self._running_summary: str = ""
+        self._last_compaction_end_index: int = 0
 
     # ------------------------------------------------------------------
     # Summarizer (lazy init for backwards compatibility)
@@ -129,24 +131,58 @@ class MemoryManager:
     async def compact(self, messages: Optional[list["Message"]] = None) -> bool:
         """Compress conversation history using the configured summarizer.
 
+        On the first compaction, the entire middle message segment is
+        summarised and stored as a running summary.  On subsequent
+        compactions only **new** messages since the last compaction are
+        summarised, and the result is merged with the existing running
+        summary.
+
         System messages and recent messages (with their tool chains) are
-        preserved.  Middle messages are summarised and the result is
-        injected as a **user** message so the agent treats it as
-        prior-conversation context rather than a constraint.
+        preserved.  The merged summary is injected as a **user** message
+        so the agent treats it as prior-conversation context rather than
+        a constraint.
         """
         msgs = messages if messages is not None else self.messages
         system = [m for m in msgs if m.role == "system"]
         non_system = [m for m in msgs if m.role != "system"]
         recent = self._recent_with_tool_chains(non_system)
-        middle = non_system[: max(0, len(non_system) - len(recent))]
+        recent_boundary = max(0, len(non_system) - len(recent))
+
+        if self._running_summary:
+            # Subsequent compaction: only summarise new messages since
+            # the last compaction, then merge with the running summary.
+            middle = non_system[self._last_compaction_end_index : recent_boundary]
+        else:
+            # First compaction: summarise the full middle segment.
+            middle = non_system[:recent_boundary]
 
         if not middle:
+            # No new middle messages to summarise — still apply the
+            # running summary + recent window.
+            if self._running_summary:
+                summary_msg = Message(role="user", content=self._running_summary)
+                msgs[:] = system + [summary_msg] + recent
+                self._last_compaction_end_index = recent_boundary
+                logger.info(
+                    "[Memory] Compacted to %d messages (no new middle, reused running summary)",
+                    len(msgs),
+                )
+                return True
             msgs[:] = system + recent
             logger.info("[Memory] Compacted to %d messages", len(msgs))
             return True
 
         summarizer = self._get_summarizer()
         if summarizer is None:
+            if self._running_summary:
+                summary_msg = Message(role="user", content=self._running_summary)
+                msgs[:] = system + [summary_msg] + recent
+                self._last_compaction_end_index = recent_boundary
+                logger.info(
+                    "[Memory] Compacted to %d messages (no summarizer, reused running summary)",
+                    len(msgs),
+                )
+                return True
             msgs[:] = system + recent
             logger.info("[Memory] Compacted to %d messages (no summarizer available)", len(msgs))
             return True
@@ -156,15 +192,32 @@ class MemoryManager:
         middle_tokens = self.count_tokens(middle)
         summary_budget = int(middle_tokens * 0.30)
 
-        summary = await summarizer.summarize(middle, budget=summary_budget)
-        if not summary:
+        new_summary = await summarizer.summarize(middle, budget=summary_budget)
+        if not new_summary:
+            if self._running_summary:
+                summary_msg = Message(role="user", content=self._running_summary)
+                msgs[:] = system + [summary_msg] + recent
+                self._last_compaction_end_index = recent_boundary
+                logger.info(
+                    "[Memory] Compacted to %d messages (summary unavailable, reused running summary)",
+                    len(msgs),
+                )
+                return True
             msgs[:] = system + recent
             logger.info("[Memory] Compacted to %d messages (summary unavailable)", len(msgs))
             return True
 
+        if self._running_summary:
+            merged = await self._merge_summaries(self._running_summary, new_summary)
+            self._running_summary = merged
+        else:
+            self._running_summary = new_summary
+
+        self._last_compaction_end_index = recent_boundary
+
         summary_message = Message(
             role="user",
-            content=summary,
+            content=self._running_summary,
         )
         msgs[:] = system + [summary_message] + recent
         logger.info("[Memory] Compacted to %d messages with summary", len(msgs))
@@ -200,6 +253,33 @@ class MemoryManager:
             after_tokens=self.count_tokens(msgs),
             reason="compacted",
         )
+
+    async def _merge_summaries(self, previous: str, new_events: str) -> str:
+        """Merge a running summary with new events into one coherent summary.
+
+        For small outputs a simple concatenation is used to avoid an LLM
+        call.  Otherwise the summarizer's ``merge`` method is tried; if
+        it is not supported the method falls back to concatenation.
+        """
+        if len(previous) + len(new_events) < 1000:
+            return previous + "\n\n---\n\n" + new_events
+
+        summarizer = self._get_summarizer()
+        if summarizer is None:
+            return previous + "\n\n---\n\n" + new_events
+
+        if hasattr(summarizer, "merge"):
+            try:
+                result = await summarizer.merge(previous, new_events)
+                if result:
+                    return result
+            except Exception:
+                logger.warning(
+                    "[Memory] merge() failed, falling back to concatenation",
+                    exc_info=True,
+                )
+
+        return previous + "\n\n---\n\n" + new_events
 
     # ------------------------------------------------------------------
     # Tool chain protection
@@ -248,3 +328,5 @@ class MemoryManager:
 
     def clear(self) -> None:
         self.messages = [m for m in self.messages if m.role == "system"]
+        self._running_summary = ""
+        self._last_compaction_end_index = 0

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -162,7 +162,7 @@ class MemoryManager:
             if self._running_summary:
                 summary_msg = Message(role="user", content=self._running_summary)
                 msgs[:] = system + [summary_msg] + recent
-                self._last_compaction_end_index = recent_boundary
+                self._last_compaction_end_index = 1  # summary is at non_system[0]
                 logger.info(
                     "[Memory] Compacted to %d messages (no new middle, reused running summary)",
                     len(msgs),
@@ -177,7 +177,7 @@ class MemoryManager:
             if self._running_summary:
                 summary_msg = Message(role="user", content=self._running_summary)
                 msgs[:] = system + [summary_msg] + recent
-                self._last_compaction_end_index = recent_boundary
+                self._last_compaction_end_index = 1  # summary is at non_system[0]
                 logger.info(
                     "[Memory] Compacted to %d messages (no summarizer, reused running summary)",
                     len(msgs),
@@ -197,7 +197,7 @@ class MemoryManager:
             if self._running_summary:
                 summary_msg = Message(role="user", content=self._running_summary)
                 msgs[:] = system + [summary_msg] + recent
-                self._last_compaction_end_index = recent_boundary
+                self._last_compaction_end_index = 1  # summary is at non_system[0]
                 logger.info(
                     "[Memory] Compacted to %d messages (summary unavailable, reused running summary)",
                     len(msgs),
@@ -213,7 +213,7 @@ class MemoryManager:
         else:
             self._running_summary = new_summary
 
-        self._last_compaction_end_index = recent_boundary
+        self._last_compaction_end_index = 1  # summary is at non_system[0]
 
         summary_message = Message(
             role="user",
@@ -271,7 +271,7 @@ class MemoryManager:
         if hasattr(summarizer, "merge"):
             try:
                 result = await summarizer.merge(previous, new_events)
-                if result:
+                if result is not None:
                     return result
             except Exception:
                 logger.warning(

--- a/agent/question.py
+++ b/agent/question.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class Question:
+    question_id: str
+    title: str          # Short label (max 80 chars)
+    body: str           # Detailed question, markdown supported
+    options: list[str]  # Empty = free text input
+
+    def to_event_data(self) -> dict[str, Any]:
+        return {
+            "question_id": self.question_id,
+            "title": self.title,
+            "body": self.body,
+            "options": self.options,
+        }
+
+
+@dataclass(frozen=True)
+class QuestionAnswer:
+    question_id: str
+    answer: str
+
+
+class QuestionHandler(Protocol):
+    async def ask_question(self, question: Question) -> QuestionAnswer:
+        ...
+
+
+class FailClosedQuestionHandler:
+    async def ask_question(self, question: Question) -> QuestionAnswer:
+        return QuestionAnswer(
+            question_id=question.question_id,
+            answer="[Error: user questions are not available in this runtime]",
+        )

--- a/agent/result.py
+++ b/agent/result.py
@@ -25,4 +25,6 @@ class RunResult:
     stop_reason: StopReason
     tool_calls_made: list[ToolCallMade]
     total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
     error: Optional[str] = None

--- a/agent/subagent/manager.py
+++ b/agent/subagent/manager.py
@@ -32,6 +32,8 @@ class SubagentArtifact:
 class SubagentRunUsage:
     total_tokens: int = 0
     tool_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 @dataclass
@@ -57,6 +59,8 @@ class SubagentRunRecord:
             "usage": {
                 "total_tokens": self.usage.total_tokens,
                 "tool_calls": self.usage.tool_calls,
+                "input_tokens": self.usage.input_tokens,
+                "output_tokens": self.usage.output_tokens,
             },
             "artifacts": [
                 {"path": artifact.path, "kind": artifact.kind}
@@ -336,6 +340,8 @@ class SubAgentManager:
         run.usage = SubagentRunUsage(
             total_tokens=result.total_tokens,
             tool_calls=len(result.tool_calls_made),
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
         )
         run.finished_at = time.time()
         run.trace = trace.to_dict()

--- a/agent/tools/builtin/ask_user.py
+++ b/agent/tools/builtin/ask_user.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+
+from agent.question import FailClosedQuestionHandler, Question, QuestionHandler
+from agent.tools.base import Tool, tool_parameters
+
+
+@tool_parameters(
+    name="AskUserQuestion",
+    description=(
+        "Ask the user a question to gather requirements, clarify ambiguity, "
+        "or request input. The agent pauses until the user responds."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Short question label (max 80 chars)",
+            },
+            "body": {
+                "type": "string",
+                "description": "Detailed question body (markdown supported)",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Predefined answer choices. Empty array = free-text input.",
+            },
+        },
+        "required": ["title", "body"],
+    },
+)
+class AskUserQuestionTool(Tool):
+    read_only = True
+    parallelizable = False  # MUST be serial — blocks until user responds
+
+    def __init__(self, question_handler: QuestionHandler | None = None) -> None:
+        from agent.question import FailClosedQuestionHandler
+        self._handler: QuestionHandler = question_handler or FailClosedQuestionHandler()
+
+    async def execute(self, title: str = "", body: str = "", options: list[str] | None = None, **kwargs) -> str:
+        options = options or []
+        question = Question(
+            question_id=str(uuid.uuid4()),
+            title=title[:80] if title else "",
+            body=body or "",
+            options=options,
+        )
+        answer = await self._handler.ask_question(question)
+        return answer.answer

--- a/agent/tools/factory.py
+++ b/agent/tools/factory.py
@@ -38,6 +38,7 @@ logger = logging.getLogger("asterwynd.tools.factory")
 
 
 KNOWN_BUILTIN_TOOL_NAMES = {
+    "AskUserQuestion",
     "Bash",
     "Edit",
     "Find",

--- a/benchmarks/agent_runner.py
+++ b/benchmarks/agent_runner.py
@@ -375,4 +375,6 @@ class AsterwyndRunner(AgentRunner):
                 else BenchmarkReason.MAX_ITERATIONS.value
             ),
             output=result.content,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
         )

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -11,6 +11,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from agent.cost_tracker import compute_cost, format_cost
+
 
 RESULT_ORDER = ["passed", "passed_with_warnings", "unsupported", "failed", "error"]
 
@@ -97,6 +99,31 @@ def build_summary(runs: list[tuple[str, dict[str, dict]]]) -> str:
             row = [name, "-", "-", "-", "-"]
         lines.append("| " + " | ".join(row) + " |")
 
+    # Cost Estimate
+    lines.append("")
+    lines.append("## Cost Estimate")
+    lines.append("")
+    cost_header = ["Agent", "Input Tokens", "Output Tokens", "Est. Cost"]
+    lines.append("| " + " | ".join(cost_header) + " |")
+    lines.append("|" + "|".join(["------"] * len(cost_header)) + "|")
+    for name, results in runs:
+        total_input = sum(
+            r.get("input_tokens", 0) or 0
+            for r in results.values()
+        )
+        total_output = sum(
+            r.get("output_tokens", 0) or 0
+            for r in results.values()
+        )
+        model = next(
+            (r.get("model", "") for r in results.values() if r.get("model")),
+            "",
+        )
+        cost = compute_cost(model, total_input, total_output)
+        lines.append(
+            f"| {name} | {total_input} | {total_output} | {format_cost(cost)} |"
+        )
+
     return "\n".join(lines) + "\n"
 
 
@@ -146,6 +173,24 @@ def build_html(runs: list[tuple[str, dict[str, dict]]]) -> str:
         else:
             latency_rows += f"<tr><td>{name}</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>"
 
+    # Cost estimate rows for HTML
+    cost_rows = ""
+    for name, results in runs:
+        total_input = sum(
+            r.get("input_tokens", 0) or 0
+            for r in results.values()
+        )
+        total_output = sum(
+            r.get("output_tokens", 0) or 0
+            for r in results.values()
+        )
+        model = next(
+            (r.get("model", "") for r in results.values() if r.get("model")),
+            "",
+        )
+        cost = compute_cost(model, total_input, total_output)
+        cost_rows += f"<tr><td>{name}</td><td>{total_input}</td><td>{total_output}</td><td>{format_cost(cost)}</td></tr>"
+
     return f"""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Cross-Agent Benchmark</title>
 <style>
@@ -176,6 +221,11 @@ small {{ color: #888; font-weight: normal; }}
 <table>
 <thead><tr><th>Agent</th><th>p50</th><th>p95</th><th>p99</th><th>Max</th></tr></thead>
 <tbody>{latency_rows}</tbody>
+</table>
+<h2>Cost Estimate</h2>
+<table>
+<thead><tr><th>Agent</th><th>Input Tokens</th><th>Output Tokens</th><th>Est. Cost</th></tr></thead>
+<tbody>{cost_rows}</tbody>
 </table>
 </body></html>"""
 

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -30,6 +30,8 @@ class AgentRunResult:
     test_runs: int = 0
     reason: str | None = None
     output: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 @dataclass

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -294,6 +294,8 @@ class BenchmarkRunner:
                         tool_calls=agent_result.tool_calls,
                         edit_count=agent_result.edit_count,
                         test_runs=0,
+                        input_tokens=agent_result.input_tokens,
+                        output_tokens=agent_result.output_tokens,
                         reason=BenchmarkReason.NO_CHANGE.value,
                     )
                     trace.record_completion("failed", BenchmarkReason.NO_CHANGE.value)
@@ -337,6 +339,8 @@ class BenchmarkRunner:
                     tool_calls=agent_result.tool_calls,
                     edit_count=agent_result.edit_count,
                     test_runs=1 if verification["status"] in {"passed", "failed"} else 0,
+                    input_tokens=agent_result.input_tokens,
+                    output_tokens=agent_result.output_tokens,
                     reason=reason,
                 )
                 trace.record_completion(status, reason or "")
@@ -413,6 +417,8 @@ class BenchmarkRunner:
                 tool_calls=agent_result.tool_calls,
                 edit_count=agent_result.edit_count,
                 test_runs=1,
+                input_tokens=agent_result.input_tokens,
+                output_tokens=agent_result.output_tokens,
                 reason=reason or agent_result.reason,
             )
             trace.record_completion(status)

--- a/tests/agent/context/test_summarizer.py
+++ b/tests/agent/context/test_summarizer.py
@@ -411,6 +411,9 @@ class TestMemoryManagerCompact:
             async def summarize(self, messages, budget=0):
                 return "custom summary"
 
+            async def merge(self, previous, new_events, budget=0):
+                return None
+
         fake = FakeSummarizer()
         assert isinstance(fake, Summarizer)
 

--- a/tests/web_tests/test_server.py
+++ b/tests/web_tests/test_server.py
@@ -500,7 +500,7 @@ def test_web_static_assets_include_session_and_run_display():
     assert "scrollHeight" not in toggle_handler
 
     tool_result_start = script.index("function addToolResultMessage")
-    tool_result_end = script.index("function renderPlanningState", tool_result_start)
+    tool_result_end = script.index("function renderQuestionCard", tool_result_start)
     tool_result_renderer = script[tool_result_start:tool_result_end]
     assert "innerHTML" not in tool_result_renderer
     assert "body.textContent" in tool_result_renderer

--- a/web/server.py
+++ b/web/server.py
@@ -363,6 +363,18 @@ def create_app(
                         },
                     })
 
+                elif msg_type == "user_answer":
+                    question_id = str(raw.get("question_id", "")).strip()
+                    answer = str(raw.get("answer", "")).strip()
+                    accepted = session.question_handler.submit_answer(question_id, answer)
+                    await ws.send_json({
+                        "type": "user_answer",
+                        "data": {
+                            "question_id": question_id,
+                            "status": "received" if accepted else "unavailable",
+                        },
+                    })
+
                 elif msg_type == "reset":
                     session.approval_handler.fail_pending("session reset")
                     session_manager.remove_session(session.session_id)

--- a/web/server.py
+++ b/web/server.py
@@ -377,6 +377,7 @@ def create_app(
 
                 elif msg_type == "reset":
                     session.approval_handler.fail_pending("session reset")
+                    session.question_handler.fail_pending("session reset")
                     session_manager.remove_session(session.session_id)
                     session = await session_manager.create_session_async(llm)
                     await ws.send_json({

--- a/web/session.py
+++ b/web/session.py
@@ -114,7 +114,12 @@ class WebQuestionHandler:
         if self._event_sender:
             self._event_sender({"type": "user_question", "data": question.to_event_data()})
         try:
-            return await future
+            return await asyncio.wait_for(future, timeout=300.0)
+        except asyncio.TimeoutError:
+            return QuestionAnswer(
+                question_id=question.question_id,
+                answer="[Error: question timed out after 5 minutes]",
+            )
         finally:
             if self._pending and self._pending[0] == question.question_id:
                 self._pending = None

--- a/web/session.py
+++ b/web/session.py
@@ -9,6 +9,7 @@ from agent.approval import (
     ApprovalRequest,
     ApprovalResponse,
 )
+from agent.question import Question, QuestionAnswer
 from agent.config import AsterwyndConfig
 from agent.loop import AgentLoop
 from agent.message import Message
@@ -89,6 +90,54 @@ class WebApprovalHandler:
             )
 
 
+class WebQuestionHandler:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self._pending: tuple[str, asyncio.Future] | None = None
+        self._event_sender = None
+
+    def set_event_sender(self, sender):
+        self._event_sender = sender
+
+    @property
+    def pending_question_id(self) -> str | None:
+        return self._pending[0] if self._pending else None
+
+    async def ask_question(self, question: Question) -> QuestionAnswer:
+        if self._pending is not None:
+            return QuestionAnswer(
+                question_id=question.question_id,
+                answer="[Error: another question is already pending]",
+            )
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending = (question.question_id, future)
+        if self._event_sender:
+            self._event_sender({"type": "user_question", "data": question.to_event_data()})
+        try:
+            return await future
+        finally:
+            if self._pending and self._pending[0] == question.question_id:
+                self._pending = None
+
+    def submit_answer(self, question_id: str, answer: str) -> bool:
+        if self._pending is None or self._pending[0] != question_id:
+            return False
+        _, future = self._pending
+        if future.done():
+            return False
+        future.set_result(QuestionAnswer(question_id=question_id, answer=answer))
+        return True
+
+    def fail_pending(self, reason: str) -> None:
+        if self._pending is None:
+            return
+        qid, future = self._pending
+        if not future.done():
+            future.set_result(
+                QuestionAnswer(question_id=qid, answer=f"[Error: {reason}]")
+            )
+
+
 class AgentSession:
     """Holds one AgentLoop instance and its message history."""
 
@@ -97,10 +146,12 @@ class AgentSession:
         session_id: str,
         agent: AgentLoop,
         approval_handler: WebApprovalHandler | None = None,
+        question_handler: WebQuestionHandler | None = None,
     ):
         self.session_id = session_id
         self.agent = agent
         self.approval_handler = approval_handler or WebApprovalHandler(session_id)
+        self.question_handler = question_handler or WebQuestionHandler(session_id)
         self.messages: list[Message] = []
         self.debug_turn = 0
 
@@ -145,6 +196,7 @@ class SessionManager:
     ) -> AgentSession:
         session_id = new_session_id()
         approval_handler = WebApprovalHandler(session_id)
+        question_handler = WebQuestionHandler(session_id)
         run_config = AgentRunConfig(mode=self.initial_mode)
         workspace_policy = WorkspacePolicy(
             command_denylist=self.config.tools.command_denylist,
@@ -182,9 +234,10 @@ class SessionManager:
             tool_result_display=self.config.tools.display,
             skill_runtime=skill_runtime,
             approval_handler=approval_handler,
+            question_handler=question_handler,
             mcp_manager=mcp_manager,
         )
-        session = AgentSession(session_id, agent, approval_handler)
+        session = AgentSession(session_id, agent, approval_handler, question_handler)
         session.init_messages()
         self._sessions[session_id] = session
         logger.info(f"Created session {session_id}")
@@ -216,6 +269,11 @@ class SessionManager:
 
         async def on_event(event_type: str, data: dict):
             await queue.put({"type": event_type, "data": data})
+
+        # Wire question handler's event sender to the queue
+        session.question_handler.set_event_sender(
+            lambda event: queue.put_nowait(event)
+        )
 
         # Add debug hook if debug is enabled
         if self.debug_enabled:
@@ -296,9 +354,24 @@ class SessionManager:
                                 },
                             })
                         continue
+                    if msg_type == "user_answer":
+                        question_id = str(raw.get("question_id", "")).strip()
+                        answer = str(raw.get("answer", "")).strip()
+                        accepted = session.question_handler.submit_answer(question_id, answer)
+                        await queue.put({
+                            "type": "user_answer",
+                            "data": {
+                                "question_id": question_id,
+                                "status": "received" if accepted else "unavailable",
+                            },
+                        })
+                        continue
                     if msg_type in {"reset", "cancel"}:
                         session.approval_handler.fail_pending(
                             f"{msg_type} received while approval was pending"
+                        )
+                        session.question_handler.fail_pending(
+                            f"{msg_type} received while question was pending"
                         )
                         continue
                     if msg_type == "ping":
@@ -308,6 +381,7 @@ class SessionManager:
             except Exception as exc:
                 logger.info("Approval response receiver stopped: %s", exc)
                 session.approval_handler.fail_pending("websocket disconnected")
+                session.question_handler.fail_pending("websocket disconnected")
 
         if ws_receive is not None:
             receiver_task = asyncio.create_task(receive_approval_responses())
@@ -320,6 +394,7 @@ class SessionManager:
                 await ws_send(event)
         finally:
             session.approval_handler.fail_pending("session run ended")
+            session.question_handler.fail_pending("session run ended")
             if receiver_task is not None and not receiver_task.done():
                 receiver_task.cancel()
                 try:

--- a/web/static/chat.js
+++ b/web/static/chat.js
@@ -12,6 +12,7 @@ let slashMatches = [];
 let activeSlashIndex = 0;
 let shouldReconnect = true;
 const approvalCards = new Map();
+const questionCards = new Map();
 let pendingImages = [];
 let sendInFlight = false;
 const wsUploadWaiters = new Map();
@@ -187,6 +188,15 @@ function handleEvent(event) {
 
     case 'approval_response':
       renderApprovalResponse(event.data || {});
+      break;
+
+    case 'user_question':
+      currentAssistantMsg = null;
+      renderQuestionCard(event.data || {});
+      break;
+
+    case 'user_answer':
+      renderQuestionResponse(event.data || {});
       break;
 
     case 'done':
@@ -515,6 +525,110 @@ function renderApprovalResponse(data) {
   card.approve.disabled = true;
   card.deny.disabled = true;
   card.status.textContent = data.status || 'completed';
+}
+
+function renderQuestionCard(data) {
+  const questionId = data.question_id;
+  if (!questionId) return;
+
+  const el = document.createElement('div');
+  el.className = 'question-card';
+
+  const header = document.createElement('div');
+  header.className = 'question-card-header';
+
+  const icon = document.createElement('span');
+  icon.className = 'question-icon';
+  icon.textContent = '?';
+  header.appendChild(icon);
+
+  const title = document.createElement('span');
+  title.textContent = data.title || 'Question';
+  header.appendChild(title);
+  el.appendChild(header);
+
+  if (data.body) {
+    const body = document.createElement('div');
+    body.className = 'question-card-body';
+    if (window.AsterwyndMarkdown && typeof window.AsterwyndMarkdown.render === 'function') {
+      body.innerHTML = window.AsterwyndMarkdown.render(data.body);
+    } else {
+      body.textContent = data.body;
+    }
+    el.appendChild(body);
+  }
+
+  const controls = document.createElement('div');
+  controls.className = 'question-controls';
+
+  let inputEl;
+  const options = Array.isArray(data.options) ? data.options : [];
+
+  if (options.length > 0) {
+    const optionsGroup = document.createElement('div');
+    optionsGroup.className = 'question-options-group';
+    options.forEach((opt, i) => {
+      const label = document.createElement('label');
+      label.className = 'question-option';
+      const radio = document.createElement('input');
+      radio.type = 'radio';
+      radio.name = `question-${questionId}`;
+      radio.value = opt;
+      if (i === 0) radio.checked = true;
+      label.appendChild(radio);
+      label.appendChild(document.createTextNode(' ' + opt));
+      optionsGroup.appendChild(label);
+    });
+    controls.appendChild(optionsGroup);
+  } else {
+    inputEl = document.createElement('input');
+    inputEl.type = 'text';
+    inputEl.className = 'question-text-input';
+    inputEl.placeholder = 'Type your answer...';
+    controls.appendChild(inputEl);
+  }
+
+  const submitBtn = document.createElement('button');
+  submitBtn.type = 'button';
+  submitBtn.className = 'question-submit';
+  submitBtn.textContent = 'Submit';
+  submitBtn.addEventListener('click', () => {
+    let answer = '';
+    if (options.length > 0) {
+      const checked = controls.querySelector(`input[name="question-${questionId}"]:checked`);
+      answer = checked ? checked.value : '';
+    } else if (inputEl) {
+      answer = inputEl.value.trim();
+    }
+    if (!answer) return;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Submitted';
+    sendQuestionAnswer(questionId, answer);
+  });
+
+  controls.appendChild(submitBtn);
+  el.appendChild(controls);
+
+  messagesEl.appendChild(el);
+  questionCards.set(questionId, { el, submitBtn });
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function sendQuestionAnswer(questionId, answer) {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({
+    type: 'user_answer',
+    question_id: questionId,
+    answer,
+  }));
+}
+
+function renderQuestionResponse(data) {
+  const questionId = data.question_id;
+  const card = questionCards.get(questionId);
+  if (!card) return;
+  card.submitBtn.disabled = true;
+  card.submitBtn.textContent = data.status === 'received' ? 'Received' : 'Unavailable';
 }
 
 function renderPlanningState(state) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -761,6 +761,123 @@ main { flex: 1; min-height: 0; overflow: hidden; }
   border-color: var(--accent);
 }
 
+/* Question card */
+.question-card {
+  align-self: stretch;
+  border: 1px solid var(--border);
+  background: var(--panel, var(--surface));
+  border-radius: 8px;
+  padding: 12px;
+  max-width: 760px;
+  display: grid;
+  gap: 8px;
+}
+
+.question-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.question-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.question-card-body {
+  color: var(--text);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.question-card-body p:last-child {
+  margin-bottom: 0;
+}
+
+.question-card-body code {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+.question-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.question-options-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 200px;
+}
+
+.question-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.88rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.question-option input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+.question-text-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+}
+
+.question-text-input:focus {
+  border-color: var(--accent);
+}
+
+.question-submit {
+  padding: 6px 14px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.question-submit:hover {
+  opacity: 0.9;
+}
+
+.question-submit:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /* Loading spinner */
 .spinner {
   display: inline-block;


### PR DESCRIPTION
## 概述

Phase 2 面试差距修复：Token 追踪全链路接线、增量压缩摘要、AskUserQuestion 人机交互工具。

## 改动内容

### QW1+QW5: Token 追踪 + 成本面板
- `AgentLoop._run()` 累计每次 LLM 调用的 token 用量
- `RunResult` 新增 `input_tokens` / `output_tokens` 字段，三处 return 点全部传值
- `TokenBudgetHook.after_llm_call` 接入真实 usage，注册到生产 hooks
- 新增 `agent/cost_tracker.py` 模型定价表（GPT/Claude/DeepSeek 共 8 个模型族）
- `AgentRunResult` / `TaskResult` / `SubagentRunUsage` 全线传递 token 数据
- Benchmark 报告新增 Cost Estimate 成本估算章节

### Feature #3: 增量压缩摘要
- `MemoryManager` 维护 `_running_summary` 和 `_last_compaction_end_index` 状态
- 首次压缩全量摘要，后续只摘要新增消息 → merge 到 running summary
- `Summarizer` 协议新增 `merge()` 方法，`LLMSummarizer` 通过 LLM 合并摘要
- 摘要 < 1000 字符直接拼接，合并失败降级 → 零额外配置

**压缩完整流程**：
```
每次迭代末尾检查 token 数 >= compact_trigger_tokens？
  → 是 & 距上次 >= 5 轮 → compact()
    1. system 消息完整保留
    2. recent 窗口（10 条 + tool 配对）保留
    3. middle 增量摘要 + merge → user 消息注入
    4. 消息列表替换为: system + [摘要] + recent
```

### Feature #4: AskUserQuestion 工具
- 新增 `QuestionHandler` 协议（独立于 `ApprovalHandler`）
- CLI: `CliQuestionHandler`（stdin/stdout 交互）
- Web: `WebQuestionHandler`（Future + WebSocket 事件 + 前端问卷卡片）
- 工具支持预定义选项和自由文本两种模式
- `parallelizable = False`，暂停 AgentLoop 直到用户回答

## 测试

```
417 passed (memory 41 + hooks 11 + context 5 + tools 237 + benchmark 40 + ...) — 全绿
```

## 文件统计

20 files changed, 705 insertions(+), 9 deletions(-)