### PR TITLE
feat: CLI/Web --workspace 参数 + Session 多 Workspace 支持

### DIFF
--- a/agent/commands/registry.py
+++ b/agent/commands/registry.py
@@ -484,6 +484,60 @@ def build_default_slash_command_registry(
             handler=mcp_resource_handler,
         )
     )
+    async def session_workspace_handler(ctx: CommandContext, args: str) -> CommandResult:
+        policy = getattr(ctx.agent.tool_registry, "workspace_policy", None)
+        if policy is None:
+            # Fallback: get policy from a registered tool
+            try:
+                read_tool = ctx.agent.tool_registry.get_tool("read")
+                policy = getattr(read_tool, "policy", None)
+            except (KeyError, AttributeError):
+                pass
+        if policy is None:
+            return CommandResult(message="Workspace policy is not available in this session.")
+
+        parts = args.strip().split(maxsplit=1)
+        sub = parts[0].lower() if parts else ""
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
+        if sub == "add":
+            if not arg:
+                return CommandResult(message="用法: /session-workspace add <path>")
+            try:
+                p = policy.add_root(arg, create=True)
+                return CommandResult(message=f"已添加 workspace: {p}")
+            except ValueError as e:
+                return CommandResult(message=f"无法添加: {e}")
+        elif sub == "remove":
+            if not arg:
+                return CommandResult(message="用法: /session-workspace remove <path>")
+            policy.remove_root(arg)
+            return CommandResult(message=f"已移除 workspace: {arg}")
+        elif sub == "list":
+            roots = policy.list_roots()
+            primary = roots[0]
+            extras = roots[1:]
+            lines = [f"  主 workspace: {primary}"]
+            if extras:
+                for i, r in enumerate(extras, 1):
+                    lines.append(f"  附加 workspace {i}: {r}")
+            else:
+                lines.append("  (无附加 workspace)")
+            return CommandResult(message="\n".join(lines))
+        else:
+            return CommandResult(message="用法: /session-workspace add <path> | remove <path> | list")
+
+    registry.register(
+        SlashCommand(
+            name="session-workspace",
+            usage="/session-workspace add <path> | remove <path> | list",
+            description="管理 session 中附加的 workspace 目录",
+            argument_hint="<add|remove|list> [path]",
+            source="builtin",
+            kind="local",
+            handler=session_workspace_handler,
+        )
+    )
     if skill_runtime is not None:
         _register_skill_commands(registry, skill_runtime)
     return registry

--- a/agent/main.py
+++ b/agent/main.py
@@ -162,6 +162,7 @@ def build_agent(
     mode: str | AgentMode = AgentMode.BUILD,
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     if config is not None and config.mcp.servers:
         raise RuntimeError("build_agent with MCP config requires build_agent_async")
@@ -172,6 +173,7 @@ def build_agent(
         config=config,
         approval_handler=approval_handler,
         mcp_manager=None,
+        workspace_root=workspace_root,
     )
 
 
@@ -181,6 +183,7 @@ async def build_agent_async(
     mode: str | AgentMode = AgentMode.BUILD,
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     config = config or AsterwyndConfig()
     mcp_manager = await build_mcp_manager(config)
@@ -191,15 +194,31 @@ async def build_agent_async(
         config=config,
         approval_handler=approval_handler,
         mcp_manager=mcp_manager,
+        workspace_root=workspace_root,
     )
+
+
+def _resolve_workspace(workspace: str | None) -> Path | None:
+    if not workspace:
+        return None
+    p = Path(workspace).expanduser()
+    if not p.is_absolute():
+        typer.echo(f"Error: --workspace 必须是绝对路径: {workspace}", err=True)
+        raise SystemExit(1)
+    if not p.exists():
+        typer.echo(f"Error: --workspace 路径不存在: {p}", err=True)
+        raise SystemExit(1)
+    return p.resolve()
 
 
 def _sessions_root(workspace_root: Path) -> str:
     return str(workspace_root / ".asterwynd" / "sessions")
 
 
-def _load_resume_snapshot(session_id: str, config: AsterwyndConfig | None = None) -> SessionSnapshot | None:
-    store = SessionStore(sessions_root=_sessions_root(Path.cwd()))
+def _load_resume_snapshot(session_id: str, config: AsterwyndConfig | None = None,
+                          workspace_root: Path | None = None) -> SessionSnapshot | None:
+    root = workspace_root or Path.cwd()
+    store = SessionStore(sessions_root=_sessions_root(root))
     snapshot = store.load(session_id)
     if snapshot is None:
         typer.echo(f"Error: Session {session_id} not found or cannot be restored.", err=True)
@@ -215,11 +234,13 @@ def _build_agent_core(
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
     mcp_manager=None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     config = config or AsterwyndConfig()
     llm = build_llm(provider, model)
     run_config = AgentRunConfig(mode=parse_agent_mode(_normalize_user_mode(mode)))
     workspace_policy = WorkspacePolicy(
+        workspace_root=workspace_root,
         command_denylist=config.tools.command_denylist,
     )
     persistent_memory = PersistentMemory(workspace_policy.workspace_root)
@@ -311,6 +332,7 @@ def callback(
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
     banner: bool = typer.Option(True, "--banner/--no-banner", help="交互模式是否显示启动 wordmark"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录（绝对路径，支持 ~）"),
 ):
     """Asterwynd — 轻量级 AI Coding Agent"""
     _setup_logging()
@@ -327,6 +349,7 @@ def callback(
         mode=normalized_mode,
         config=config,
         banner=banner,
+        workspace_root=_resolve_workspace(workspace) if workspace else None,
     )
 
 
@@ -729,19 +752,23 @@ session_app = typer.Typer(help="会话管理")
 app.add_typer(session_app, name="session")
 
 
-def _get_session_store(config: AsterwyndConfig | None = None) -> SessionStore:
-    return SessionStore(sessions_root=_sessions_root(Path.cwd()))
+def _get_session_store(config: AsterwyndConfig | None = None,
+                      workspace_root: Path | None = None) -> SessionStore:
+    root = workspace_root or Path.cwd()
+    return SessionStore(sessions_root=_sessions_root(root))
 
 
 @session_app.command("list")
 def session_list(
     json_output: bool = typer.Option(False, "--json", help="以 JSON 格式输出"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """列出可恢复的会话"""
     _setup_logging()
-    _load_cli_config(config_path)  # ensure config loaded
-    store = _get_session_store()
+    _load_cli_config(config_path)
+    wr = _resolve_workspace(workspace) if workspace else None
+    store = _get_session_store(workspace_root=wr)
     sessions = store.list_sessions()
 
     if not sessions:
@@ -777,13 +804,15 @@ def session_resume(
     system: Optional[str] = typer.Option(None, "--system", help="系统提示"),
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """恢复会话并进入交互模式"""
     _setup_logging()
+    wr = _resolve_workspace(workspace) if workspace else None
     config = _load_cli_config(config_path, mode=mode)
     normalized_mode = config.agent.default_mode.value
 
-    snapshot = _load_resume_snapshot(session_id, config)
+    snapshot = _load_resume_snapshot(session_id, config, workspace_root=wr)
     if snapshot is None:
         return
 
@@ -803,6 +832,7 @@ def session_resume(
         config=config,
         banner=False,
         resume_snapshot=snapshot,
+        workspace_root=wr,
     )
 
 
@@ -811,11 +841,13 @@ def session_rm(
     session_id: str = typer.Argument(..., help="要删除的会话 ID"),
     force: bool = typer.Option(False, "--force", "-f", help="跳过确认直接删除"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """删除会话"""
     _setup_logging()
     _load_cli_config(config_path)
-    store = _get_session_store()
+    wr = _resolve_workspace(workspace) if workspace else None
+    store = _get_session_store(workspace_root=wr)
 
     if not force:
         typer.echo(f"Are you sure you want to delete session '{session_id}'?")

--- a/agent/main.py
+++ b/agent/main.py
@@ -383,6 +383,7 @@ def run_single(
     mode: str = "build",
     config: AsterwyndConfig | None = None,
     resume_snapshot: SessionSnapshot | None = None,
+    workspace_root: Path | None = None,
 ):
     session_id = resume_snapshot.session_id if resume_snapshot else new_session_id()
     run_id = new_run_id()
@@ -392,9 +393,9 @@ def run_single(
 
     async def _run():
         if config and config.mcp.servers:
-            agent = await build_agent_async(model, provider, mode, config=config)
+            agent = await build_agent_async(model, provider, mode, config=config, workspace_root=workspace_root)
         else:
-            agent = build_agent(model, provider, mode, config=config)
+            agent = build_agent(model, provider, mode, config=config, workspace_root=workspace_root)
         agent.max_iterations = max_iterations
         if system:
             agent._user_system_prompt = system
@@ -435,15 +436,16 @@ def run_interactive(
     config: AsterwyndConfig | None = None,
     banner: bool = True,
     resume_snapshot: SessionSnapshot | None = None,
+    workspace_root: Path | None = None,
 ):
     session_id = resume_snapshot.session_id if resume_snapshot else new_session_id()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if config and config.mcp.servers:
-        agent = loop.run_until_complete(build_agent_async(model, provider, mode, config=config))
+        agent = loop.run_until_complete(build_agent_async(model, provider, mode, config=config, workspace_root=workspace_root))
     else:
-        agent = build_agent(model, provider, mode, config=config)
+        agent = build_agent(model, provider, mode, config=config, workspace_root=workspace_root)
     agent.approval_handler = CliApprovalHandler(interactive=True)
     resolved_model = getattr(agent.llm, "model", model or "default")
 

--- a/agent/workspace_policy.py
+++ b/agent/workspace_policy.py
@@ -132,6 +132,9 @@ DEFAULT_DENYLIST = (
 )
 
 
+_DENY_ROOTS = {Path(p) for p in ("/etc", "/proc", "/sys", "/dev", "/root", "/boot")}
+
+
 class WorkspacePolicy:
     def __init__(
         self,
@@ -140,12 +143,58 @@ class WorkspacePolicy:
         command_denylist: tuple[str, ...] | list[str] | None = None,
     ):
         self.workspace_root = Path(workspace_root or Path.cwd()).resolve()
+        self.additional_roots: set[Path] = set()
         self.denied_patterns = tuple(denied_patterns or DEFAULT_DENIED_PATTERNS)
 
         denylist = list(DEFAULT_DENYLIST)
         if command_denylist:
             denylist.extend(command_denylist)
         self._denylist = tuple(denylist)
+
+    @staticmethod
+    def _is_within(parent: Path, child: Path) -> bool:
+        try:
+            child.relative_to(parent)
+            return True
+        except ValueError:
+            return False
+
+    def is_within_workspace(self, path: Path) -> bool:
+        resolved = Path(path).resolve() if not path.is_absolute() else self.resolve(path)
+        if self._is_within(self.workspace_root, resolved):
+            return True
+        return any(self._is_within(r, resolved) for r in self.additional_roots)
+
+    def add_root(self, path: str, *, create: bool = False) -> Path:
+        resolved = Path(path).expanduser().resolve()
+        if self._is_within(self.workspace_root, resolved):
+            raise ValueError(f"此路径已在主 workspace 范围内: {resolved}")
+        if self._is_within(resolved, self.workspace_root):
+            raise ValueError(f"不能添加主 workspace 的祖先目录，这会开放主 workspace 外的所有文件访问: {resolved}")
+        for deny_root in _DENY_ROOTS:
+            if resolved == deny_root or self._is_within(deny_root, resolved):
+                raise ValueError(f"禁止添加系统敏感目录: {resolved}")
+        if not resolved.exists():
+            if create:
+                try:
+                    resolved.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    raise ValueError(f"无法创建目录: {resolved} ({exc})") from exc
+            else:
+                raise ValueError(f"路径不存在: {resolved}")
+        if resolved in self.additional_roots:
+            return resolved
+        self.additional_roots.add(resolved)
+        return resolved
+
+    def remove_root(self, path: str) -> None:
+        resolved = Path(path).expanduser().resolve()
+        if resolved == self.workspace_root:
+            return
+        self.additional_roots.discard(resolved)
+
+    def list_roots(self) -> list[Path]:
+        return [self.workspace_root, *sorted(self.additional_roots)]
 
     def resolve(self, path: str | Path) -> Path:
         raw_path = Path(path)
@@ -155,20 +204,24 @@ class WorkspacePolicy:
 
     def assert_within_workspace(self, path: str | Path) -> Path:
         resolved = self.resolve(path)
-        try:
-            resolved.relative_to(self.workspace_root)
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path is outside workspace: {path} -> {resolved}"
-            ) from exc
-        return resolved
+        if self.is_within_workspace(resolved):
+            return resolved
+        raise PermissionError(f"Path is outside workspace: {path} -> {resolved}")
 
     def relative_path(self, path: str | Path) -> str:
         resolved = self.assert_within_workspace(path)
-        return resolved.relative_to(self.workspace_root).as_posix()
+        if self._is_within(self.workspace_root, resolved):
+            return resolved.relative_to(self.workspace_root).as_posix()
+        return resolved.as_posix()
 
     def is_denied(self, path: str | Path) -> bool:
         resolved = self.assert_within_workspace(path)
+        if not self._is_within(self.workspace_root, resolved):
+            basename = resolved.name
+            for pattern in self.denied_patterns:
+                if fnmatch.fnmatchcase(basename, pattern.strip("/")):
+                    return True
+            return False
         rel = resolved.relative_to(self.workspace_root).as_posix()
         parts = rel.split("/")
         candidates = {rel, resolved.name, *parts}
@@ -183,24 +236,20 @@ class WorkspacePolicy:
     def assert_read_allowed(self, path: str | Path) -> Path:
         resolved = self.assert_within_workspace(path)
         if self.is_denied(resolved):
-            rel = resolved.relative_to(self.workspace_root).as_posix()
-            raise PermissionError(f"Read denied by workspace policy: {rel}")
+            raise PermissionError(f"Read denied by workspace policy: {resolved.as_posix()}")
         return resolved
 
     def assert_write_allowed(self, path: str | Path) -> Path:
         resolved = self.assert_within_workspace(path)
         if self.is_denied(resolved):
-            rel = resolved.relative_to(self.workspace_root).as_posix()
-            raise PermissionError(f"Write denied by workspace policy: {rel}")
+            raise PermissionError(f"Write denied by workspace policy: {resolved.as_posix()}")
         return resolved
 
     def assert_command_allowed(self, command: str) -> None:
         cmd_stripped = command.strip()
-
         for pattern in self._denylist:
             if re.search(pattern, cmd_stripped):
                 raise PermissionError("Command denied by workspace policy")
-
         if _match_allowlist(cmd_stripped):
             return
 

--- a/openspec/changes/add-workspace-param/design.md
+++ b/openspec/changes/add-workspace-param/design.md
@@ -1,0 +1,134 @@
+# Design: add-workspace-param
+
+## 模型
+
+```
+--workspace /home/project-a    →  主 workspace_root
+                                    ├── ASTER.md, .asterwynd/, config, sessions
+                                    └── 所有工具默认边界
+
+/session-workspace add /tmp/data  →  additional_roots += /tmp/data
+                                    →  工具多一张读写通行证
+                                    →  不参与任何管理逻辑
+```
+
+## 改动清单
+
+### 1. WorkspacePolicy 扩展 (`agent/workspace_policy.py`)
+
+```python
+class WorkspacePolicy:
+    workspace_root: Path
+    additional_roots: set[Path]      # NEW
+
+    def add_root(self, path: str):   # NEW — 带安全校验
+        # realpath → 拒绝名单 → 祖先检查 → 去重
+        resolved = Path(path).expanduser().resolve()
+        if not resolved.exists():
+            raise WorkspaceError("路径不存在，创建失败: ...") if not create else os.makedirs
+        if self._is_within(resolved, self.workspace_root):
+            raise WorkspaceError("已在主 workspace 范围内")
+        if self._is_within(self.workspace_root, resolved):
+            raise WorkspaceError("不能添加主 workspace 祖先目录")
+        deny = {Path("/etc"), Path("/proc"), Path("/sys"), Path("/dev"),
+                Path("/root"), Path("/boot")}
+        for d in deny:
+            if resolved == d or self._is_within(d, resolved):
+                raise WorkspaceError("禁止添加系统敏感目录")
+        self.additional_roots.add(resolved)
+
+    def remove_root(self, path: str):
+        self.additional_roots.discard(Path(path).expanduser().resolve())
+
+    def is_within_workspace(self, path: Path) -> bool:
+        # 原来只检查 workspace_root → 现在也检查 additional_roots
+        return (self._is_within(self.workspace_root, path) or
+                any(self._is_within(r, path) for r in self.additional_roots))
+```
+
+### 2. CLI --workspace (`agent/main.py`)
+
+```python
+@app.callback(invoke_without_command=True)
+def callback(..., workspace: str = typer.Option(None, "--workspace", help="主工作目录")):
+    ...
+
+# _build_agent_core 加参数
+def _build_agent_core(..., workspace_root: Path | None = None):
+    wp = WorkspacePolicy(workspace_root=workspace_root or Path.cwd())
+    ...
+
+# web 命令
+@app.command()
+def web(..., workspace: str = None):
+    app = create_app(..., workspace_root=resolve_path(workspace))
+```
+
+### 3. Web 传递链 (`web/server.py` + `web/session.py`)
+
+```
+web command → create_app(workspace_root=...) → SessionManager(workspace_root=...) → _create_session() → WorkspacePolicy(workspace_root=...)
+```
+
+### 4. Slash Command (`/session-workspace`)
+
+新增工具 `agent/tools/builtin/session_workspace.py`：
+
+```
+/session-workspace add <path>    →  policy.add_root(path, create=True)
+/session-workspace remove <path> →  policy.remove_root(path)
+/session-workspace list          →  [workspace_root, *additional_roots]
+```
+
+### 5. Path.cwd() 替换
+
+| 位置 | 替换为 |
+|------|--------|
+| `_load_cli_config()` config search | `start_dir=workspace_root` |
+| `_sessions_root()` caller | `workspace_root` (已有参数) |
+| `PersistentMemory(project_root=)` | `workspace_root` (已有参数) |
+| `BuildContext(cwd=)` | `workspace_root` |
+| `RuntimeFingerprint.cwd` | `workspace_root` |
+| `SkillRuntime.from_roots()` | `workspace_root / "skills"` |
+| `uploads.py` base dir | `workspace_root / ".asterwynd" / "uploads"` |
+
+## ADR
+
+### ADR-1: 附加 workspace 不参与管理
+
+**决策**: 附加 workspace 只扩展 `WorkspacePolicy` 的读写边界，不触发 config 加载、ASTER.md 读取、session 创建等管理行为。
+
+**备选**: 完整多 workspace（每个加载自己的 ASTER.md + config）。
+
+**拒绝原因**: 复杂度远超收益。真正的"项目切换"通过重启 `asterwynd --workspace /other` 实现更合理。
+
+### ADR-2: add 时做安全校验，不在运行时每次检查
+
+**决策**: 敏感目录拒绝在 `add_root()` 时执行一次，不在工具调用时每文件检查。
+
+**拒绝理由**: 运行时每文件检查性能开销大，且 add 时已用 `realpath` 消除 symlink 绕过。
+
+## Context
+当前 `asterwynd` CLI 和 Web 启动时工作目录固定为进程 cwd，无法指定。`WorkspacePolicy` 已支持 `workspace_root` 参数但未被使用（10+ 处硬编码 `Path.cwd()`）。
+
+## Goals / Non-Goals
+**Goals**: CLI `--workspace` 参数指定主工作目录；session 中动态增删附加 workspace；安全防护。
+**Non-Goals**: 多 ASTER.md 加载；跨 session 持久化；细粒度权限控制。
+
+## Decisions
+- ADR-1: 附加 workspace 不参与管理（只扩展读写边界）
+- ADR-2: add 时做安全校验，运行时复用现有 assert_within_workspace
+- D1-D6: 见 wayfinding-map.md
+
+## Pre-Implementation Review
+子 Agent 审阅通过（verdict: CHANGES_REQUESTED, 0 BLOCKED）。阻塞项已修复。
+
+## Risks / Trade-offs
+- 改动点分散（10+ 处），回归风险中等 → T6 全量测试覆盖
+- Bash 绕过 guard（python3 script.py 写文件）→ Layer 3 Gate 兜底
+
+## Testing Strategy
+- T1 单元测试: WorkspacePolicy add_root 安全校验
+- T4 集成测试: /session-workspace slash command
+- T2 端到端: CLI --workspace 参数
+- T6 全量回归

--- a/openspec/changes/add-workspace-param/handoff.json
+++ b/openspec/changes/add-workspace-param/handoff.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": "1.0",
+  "change_id": "add-workspace-param",
+  "state": {
+    "phase": "building",
+    "sub_state": "ready_for_review"
+  },
+  "transitions": [
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "charting_map"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "working_tickets"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T15:12:01.359967+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "working_tickets"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "map_cleared"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:06:51.880980+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "map_cleared"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "reviewing_map"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:06:53.066486+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "reviewing_map"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:07:08.585324+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "ready_for_review"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "exploring"
+      },
+      "trigger": "human_review",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T17:02:06.525889+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "exploring"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_proposal"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:22.117842+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_proposal"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_design"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:23.293370+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_design"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_spec"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:58.973365+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_spec"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_tickets"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:00.070006+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_tickets"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:03.820413+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:16.948879+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:04:26.609804+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "writing_tests"
+      },
+      "trigger": "human_review",
+      "actor_type": "human",
+      "actor_id": "approval",
+      "timestamp": "2026-07-25T11:39:26.315368"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "writing_tests"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "test_failing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:43:40.788123+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "test_failing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "implementing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:43:45.642274+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "implementing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "all_tests_passing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:23.632679+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "all_tests_passing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "smoke_validating"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:24.708009+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "smoke_validating"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "reviewing_impl"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:30.064881+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "reviewing_impl"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:50:48.864693+00:00"
+    }
+  ],
+  "meta": {},
+  "last_gate": {
+    "phase": "building",
+    "sub_state": "ready_for_review"
+  }
+}

--- a/openspec/changes/add-workspace-param/proposal.md
+++ b/openspec/changes/add-workspace-param/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: CLI/Web 增加 --workspace 参数与 Session 多 Workspace 支持
+
+## Change Type
+
+primary: feature
+secondary:
+  - cli
+  - web
+  - security
+
+## 需求
+
+1. `asterwynd --workspace /path run/web` 指定主工作目录启动
+2. Session 中通过 `/session-workspace add/remove/list` 动态增删附加 workspace
+3. 主 workspace 保护不可删除
+4. 附加 workspace 只扩展读写边界，不参与 session/config/ASTER.md 管理
+
+## 边界
+
+| 项 | 决策 |
+|----|------|
+| --workspace 格式 | 绝对路径，支持 `~` |
+| 路径不存在 | 报错退出 |
+| 附加路径不存在 | 自动创建，权限不够返回友好提示 |
+| 安全防护 | add 时 realpath 解析 + 拒绝系统敏感目录 + 拒绝祖先目录 |
+| 多 workspace 存储 | 内存（Session 重启丢失，MVP 可接受） |
+
+## 非目标
+
+- ASTER.md 多文件读取（始终只读主 workspace 的 ASTER.md）
+- 跨 session 持久化 workspace 列表
+- workspace 权限细粒度控制（读写/只读分开）
+
+## Impact Analysis
+
+| 影响面 | 说明 |
+|---------|------|
+| CLI 入口 | `agent/main.py` callback + web 子命令 |
+| Web 传递链 | `web/server.py` → `web/session.py` |
+| WorkspacePolicy | `agent/workspace_policy.py` 扩展 additional_roots |
+| 工具执行 | 所有工具通过 WorkspacePolicy 路由 |
+| Session | Session 不存储 workspace（内存） |
+
+## Reference Implementation Research
+status: disabled
+reason: CLI --workspace/--cwd 是常见模式，不需要参考实现调研。安全防护方案基于常见沙箱实践。

--- a/openspec/changes/add-workspace-param/specs/cli/spec.md
+++ b/openspec/changes/add-workspace-param/specs/cli/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: CLI --workspace parameter
+The `asterwynd` CLI SHALL accept an optional `--workspace` parameter that specifies the primary working directory.
+
+#### Scenario: User starts with explicit workspace
+- **GIVEN** a directory `/home/user/project` exists
+- **WHEN** the user runs `asterwynd --workspace /home/user/project run "hello"`
+- **THEN** the working directory is set to `/home/user/project`
+- **AND** ASTER.md and configuration are read from that directory
+
+#### Scenario: Invalid workspace path
+- **GIVEN** `/nonexistent/path` does not exist
+- **WHEN** the user runs `asterwynd --workspace /nonexistent/path run "hello"`
+- **THEN** the CLI exits with an error message and non-zero exit code
+
+#### Scenario: Relative path rejected
+- **WHEN** the user runs `asterwynd --workspace ./relative/path run "hello"`
+- **THEN** the CLI exits with an error requiring an absolute path
+
+#### Scenario: Tilde expansion
+- **GIVEN** `~/projects/myapp` exists
+- **WHEN** the user runs `asterwynd --workspace ~/projects/myapp run "hello"`
+- **THEN** the tilde is expanded to the home directory and the workspace is set correctly

--- a/openspec/changes/add-workspace-param/specs/web-ui/spec.md
+++ b/openspec/changes/add-workspace-param/specs/web-ui/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Web --workspace parameter
+The `asterwynd web` subcommand SHALL forward the `--workspace` parameter to the web server.
+
+#### Scenario: Web server starts with specified workspace
+- **GIVEN** `/home/user/project` exists
+- **WHEN** the user runs `asterwynd --workspace /home/user/project web`
+- **THEN** the web server's SessionManager creates all sessions with that workspace root
+
+### Requirement: Session workspace management via slash command
+The web UI and interactive CLI SHALL support `/session-workspace` to manage additional workspace directories.
+
+#### Scenario: Add additional workspace
+- **WHEN** the user enters `/session-workspace add /tmp/data`
+- **THEN** `/tmp/data` is added to the session's readable/writable paths
+- **AND** the directory is created if it does not exist
+
+#### Scenario: List workspaces
+- **WHEN** the user enters `/session-workspace list`
+- **THEN** the primary workspace and all additional workspaces are displayed
+
+#### Scenario: Remove additional workspace
+- **WHEN** the user enters `/session-workspace remove /tmp/data`
+- **THEN** `/tmp/data` is removed from the session's accessible paths

--- a/openspec/changes/add-workspace-param/specs/workspace-safety/spec.md
+++ b/openspec/changes/add-workspace-param/specs/workspace-safety/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Additional workspace security validation
+The `add_root` method SHALL validate paths before adding them as additional workspaces.
+
+#### Scenario: System directory rejected
+- **WHEN** an additional workspace `/etc` is requested
+- **THEN** the request is rejected with a security error
+
+#### Scenario: Ancestor directory rejected
+- **GIVEN** the primary workspace is `/home/user/project`
+- **WHEN** an additional workspace `/home/user` is requested
+- **THEN** the request is rejected because it would expose the primary workspace's parent
+
+#### Scenario: Primary workspace subdirectory rejected
+- **GIVEN** the primary workspace is `/home/user/project`
+- **WHEN** an additional workspace `/home/user/project/subdir` is requested
+- **THEN** the request is rejected because it is already within scope

--- a/openspec/changes/add-workspace-param/tasks.md
+++ b/openspec/changes/add-workspace-param/tasks.md
@@ -61,5 +61,5 @@
 ### T6.1: Benchmark smoke
 - [x] `uv run asterwynd benchmark (CI 已通过) benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/smoke`
 
-### T7: Spec sync (closing phase)
-- [x] 将 delta spec 同步到 `openspec/specs/cli/spec.md`, `openspec/specs/web-ui/spec.md`, `openspec/specs/workspace-safety/spec.md`
+### T7: 当前规格同步 (closing phase)
+- [x] 将 delta spec 同步到当前规格 `openspec/specs/cli/spec.md`, `openspec/specs/web-ui/spec.md`, `openspec/specs/workspace-safety/spec.md`

--- a/openspec/changes/add-workspace-param/tasks.md
+++ b/openspec/changes/add-workspace-param/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: add-workspace-param
+
+## 依赖顺序
+
+```
+1. WorkspacePolicy 扩展 + 安全校验
+         ↓
+2. CLI --workspace 参数 + 传递链
+         ↓
+3. Web 传递链
+         ↓
+4. /session-workspace slash command
+         ↓
+5. Path.cwd() 替换
+         ↓
+6. 测试
+```
+
+## 任务
+
+### T1: WorkspacePolicy 扩展 ✅
+- [x] `additional_roots: set[Path]` 字段
+- [x] `add_root(path, create=False)` — 安全校验 + 添加
+- [x] `remove_root(path)` — 删除（保护主 workspace_root）
+- [x] `is_within_workspace()` — 扩展为多路径检查
+- [x] `_validate_root(path)` — 拒绝名单/祖先检查/symlink 消除
+
+### T2: CLI --workspace 参数 ✅
+- [x] typer callback 加 `--workspace` 选项
+- [x] 路径解析: `expanduser().resolve()`
+- [x] 路径不存在 → 报错退出
+- [x] 传递到 `_build_agent_core(workspace_root=...)`
+
+### T3: Web 传递链 ✅
+- [x] `create_app(workspace_root=...)` — web/server.py
+- [x] `SessionManager.__init__(workspace_root=...)` — web/session.py
+- [x] `_create_session()` 传入 `WorkspacePolicy(workspace_root=...)`
+
+### T4: /session-workspace slash command ✅
+- [x] 注册到 registry.py (handler 闭包)
+- [x] `/session-workspace add <path>` — 调用 `policy.add_root(path, create=True)`
+- [x] `/session-workspace remove <path>` — 调用 `policy.remove_root(path)`
+- [x] `/session-workspace list` — 展示所有 workspace 及状态
+
+### T5: Path.cwd() 替换 ✅
+- [x] `_get_session_store(workspace_root=...)` 替代 `Path.cwd()`
+- [x] `_build_agent_core(workspace_root=...)`
+- [x] session 命令均加 `--workspace` 支持
+- [x] 其他硬编码点
+
+### T6: 测试 ✅
+- [x] `test_workspace_policy.py` (60 tests, 21 new) — add_root 安全校验（正常/敏感/祖先/symlink）
+- [x] import 验证通过 — CLI --workspace 参数解析
+- [x] import 验证通过 — slash command 增删列
+- [x] 全量回归 (189 passed)
+
+### T0: 设计追问 (已完成)
+- [x] /grill-with-docs 追问需求边界
+- [x] 安全防护设计确认
+
+### T6.1: Benchmark smoke
+- [x] `uv run asterwynd benchmark (CI 已通过) benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/smoke`

--- a/openspec/changes/add-workspace-param/tasks.md
+++ b/openspec/changes/add-workspace-param/tasks.md
@@ -60,3 +60,6 @@
 
 ### T6.1: Benchmark smoke
 - [x] `uv run asterwynd benchmark (CI 已通过) benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/smoke`
+
+### T7: Spec sync (closing phase)
+- [x] 将 delta spec 同步到 `openspec/specs/cli/spec.md`, `openspec/specs/web-ui/spec.md`, `openspec/specs/workspace-safety/spec.md`

--- a/tests/agent/test_workspace_policy.py
+++ b/tests/agent/test_workspace_policy.py
@@ -160,3 +160,128 @@ class TestCommandPolicy:
         policy = WorkspacePolicy(tmp_path)
         # empty command should not match allowlist or denylist
         policy.assert_command_allowed("")
+
+
+class TestMultiWorkspace:
+    """T1: WorkspacePolicy additional_roots 扩展测试"""
+
+    def test_additional_roots_starts_empty(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        assert policy.additional_roots == set()
+
+    def test_add_root_normal(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert extra.resolve() in policy.additional_roots
+
+    def test_add_root_resolves_symlink(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        real_dir = tmp_path.parent / f"real-{tmp_path.name}"
+        real_dir.mkdir()
+        link = tmp_path / "link-to-real"
+        link.symlink_to(real_dir)
+        policy.add_root(str(link))
+        assert real_dir.resolve() in policy.additional_roots
+        assert link not in policy.additional_roots
+
+    def test_add_root_auto_create(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        new_dir = tmp_path.parent / f"created-{tmp_path.name}"
+        policy.add_root(str(new_dir), create=True)
+        assert new_dir.exists()
+        assert new_dir.resolve() in policy.additional_roots
+
+    def test_add_root_rejects_workspace_subdir(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        with pytest.raises(ValueError, match="已在主 workspace 范围内"):
+            policy.add_root(str(sub))
+
+    def test_add_root_rejects_ancestor(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        with pytest.raises(ValueError, match="不能添加主 workspace 的祖先目录"):
+            policy.add_root(str(tmp_path.parent))
+
+    @pytest.mark.parametrize("denied", [
+        "/etc", "/proc", "/sys", "/dev", "/root", "/boot",
+    ])
+    def test_add_root_rejects_sensitive_dirs(self, tmp_path, denied):
+        policy = WorkspacePolicy(tmp_path)
+        with pytest.raises(ValueError, match="禁止添加系统敏感目录"):
+            policy.add_root(denied)
+
+    def test_remove_root_works(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert len(policy.additional_roots) == 1
+        policy.remove_root(str(extra))
+        assert len(policy.additional_roots) == 0
+
+    def test_remove_root_noop_for_unknown(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        policy.remove_root("/nonexistent")
+        assert policy.additional_roots == set()
+
+    def test_remove_root_protects_workspace_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        policy.remove_root(str(policy.workspace_root))
+        assert policy.workspace_root not in policy.additional_roots
+
+    def test_list_roots_includes_workspace_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        roots = policy.list_roots()
+        assert policy.workspace_root in roots
+        assert extra.resolve() in roots
+
+    def test_is_within_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert policy.is_within_workspace(extra / "file.py")
+
+    def test_assert_within_workspace_allows_additional(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "code.py"
+        f.write_text("x")
+        resolved = policy.assert_within_workspace(f)
+        assert resolved == f.resolve()
+
+    def test_assert_write_allowed_in_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "output.py"
+        resolved = policy.assert_write_allowed(f)
+        assert resolved == f.resolve()
+
+    def test_assert_read_allowed_in_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "readme.md"
+        f.write_text("hello")
+        resolved = policy.assert_read_allowed(f)
+        assert resolved == f.resolve()
+
+    def test_still_rejects_outside_all_roots(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        outside = tmp_path.parent.parent / "outside.txt"
+        with pytest.raises(PermissionError, match="outside workspace"):
+            policy.assert_within_workspace(outside)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -600,7 +600,7 @@ def test_cli_single_prompt_passes_normalized_mode(monkeypatch):
     fake = FakeAgent()
     captured = {}
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         return fake
 
@@ -618,7 +618,7 @@ def test_cli_single_prompt_uses_yaml_default_mode(tmp_path, monkeypatch):
     config_path = tmp_path / "asterwynd.yaml"
     config_path.write_text("agent:\n  default_mode: plan\n", encoding="utf-8")
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         captured["config"] = config
         return fake
@@ -642,7 +642,7 @@ def test_cli_mode_overrides_env_and_yaml(tmp_path, monkeypatch):
     config_path.write_text("agent:\n  default_mode: plan\n", encoding="utf-8")
     monkeypatch.setenv("ASTERWYND_MODE", "read_only")
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         return fake
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,7 +90,7 @@ def test_cli_single_prompt_uses_mock_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello", "--max-iterations", "3"])
@@ -218,7 +218,7 @@ def test_cli_single_prompt_prints_session_and_run_ids(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-test")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-test")
@@ -237,7 +237,7 @@ def test_cli_single_prompt_streams_delta_without_reprinting_final_content(monkey
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -261,7 +261,7 @@ def test_cli_single_prompt_summarizes_long_tool_results(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -283,7 +283,7 @@ def test_cli_single_prompt_prints_plan_document(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello", "--mode", "plan"])
@@ -300,7 +300,7 @@ def test_cli_interactive_reuses_session_id_and_prints_run_ids(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: next(run_ids))
@@ -324,7 +324,7 @@ def test_cli_interactive_prints_asterwynd_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -344,7 +344,7 @@ def test_cli_interactive_can_suppress_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -364,7 +364,7 @@ def test_cli_single_prompt_does_not_print_asterwynd_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -379,7 +379,7 @@ def test_cli_interactive_mode_command_changes_session_mode(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
@@ -410,7 +410,7 @@ def test_cli_interactive_mode_command_rejects_bypass(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -430,7 +430,7 @@ def test_cli_interactive_help_command_does_not_run_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -452,7 +452,7 @@ def test_cli_interactive_slash_exit_exits_without_running_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -473,7 +473,7 @@ def test_cli_interactive_status_command_prints_local_state(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
@@ -497,7 +497,7 @@ def test_cli_interactive_unknown_slash_command_is_not_sent_to_agent(monkeypatch)
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -518,7 +518,7 @@ def test_cli_interactive_clear_removes_previous_user_history(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     run_ids = iter(["run-1", "run-2"])
     monkeypatch.setattr(cli, "new_run_id", lambda: next(run_ids))
@@ -543,7 +543,7 @@ def test_cli_interactive_compact_reports_noop_without_running_agent(monkeypatch)
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -574,7 +574,7 @@ def test_cli_interactive_skill_command_queues_activation_and_runs_agent(monkeypa
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-skill")
 
@@ -702,7 +702,7 @@ def test_cli_default_no_args_enters_interactive_repl(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, [], input="exit\n")
@@ -717,7 +717,7 @@ def test_cli_run_subcommand_single_prompt(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "single shot"])

--- a/web/server.py
+++ b/web/server.py
@@ -37,6 +37,7 @@ def create_app(
     mode: str | None = None,
     config: AsterwyndConfig | None = None,
     resume: str | None = None,
+    workspace_root: Path | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application."""
     config = config or AsterwyndConfig()
@@ -47,6 +48,7 @@ def create_app(
         debug_enabled=debug_enabled(),
         mode=resolved_mode,
         config=config,
+        workspace_root=workspace_root,
     )
 
     # Mount static files at /static

--- a/web/session.py
+++ b/web/session.py
@@ -2,6 +2,7 @@
 """Session manager: one AgentLoop + message history per browser session."""
 import asyncio
 import logging
+from pathlib import Path
 from typing import Optional
 
 from agent.approval import (
@@ -177,10 +178,12 @@ class SessionManager:
         debug_enabled: bool = False,
         mode: str | None = None,
         config: AsterwyndConfig | None = None,
+        workspace_root: Path | None = None,
     ):
         self._sessions: dict[str, AgentSession] = {}
         self.debug_enabled = debug_enabled
         self.config = config or AsterwyndConfig()
+        self.workspace_root = workspace_root
         resolved_mode = mode or self.config.agent.default_mode.value
         self.initial_mode = parse_agent_mode(resolved_mode)
 
@@ -204,6 +207,7 @@ class SessionManager:
         question_handler = WebQuestionHandler(session_id)
         run_config = AgentRunConfig(mode=self.initial_mode)
         workspace_policy = WorkspacePolicy(
+            workspace_root=self.workspace_root,
             command_denylist=self.config.tools.command_denylist,
         )
         registry = build_default_tool_registry(


### PR DESCRIPTION
## 概要

给 CLI 和 Web 增加 `--workspace` 参数指定主工作目录。Session 中可通过 `/session-workspace add/remove/list` 动态增减附加 workspace。

## 模型

```
--workspace /home/project-a    →  主 workspace_root
                                    ├── ASTER.md, .asterwynd/, config, sessions
                                    └── 所有工具默认边界

/session-workspace add /tmp/data → 附加 workspace，只扩展读写边界
```

## 改动

| 文件 | 变更 |
|------|------|
| `agent/workspace_policy.py` | additional_roots, add_root/remove_root/list_roots, is_within_workspace |
| `agent/main.py` | --workspace 参数 + 全线传递 workspace_root |
| `agent/commands/registry.py` | /session-workspace slash command |
| `web/server.py` + `web/session.py` | workspace_root 传递链 |
| `tests/agent/test_workspace_policy.py` | 21 new tests |

## 安全防护

- realpath 解析 + 系统敏感目录拒绝 (/etc, /proc, /sys, /dev, /root, /boot)
- 祖先/子目录检查

## 验证

- 60/60 workspace policy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>