### PR TITLE
feat: CLI/Web --workspace 参数 + Session 多 Workspace 支持

### DIFF
--- a/agent/commands/registry.py
+++ b/agent/commands/registry.py
@@ -484,6 +484,60 @@ def build_default_slash_command_registry(
             handler=mcp_resource_handler,
         )
     )
+    async def session_workspace_handler(ctx: CommandContext, args: str) -> CommandResult:
+        policy = getattr(ctx.agent.tool_registry, "workspace_policy", None)
+        if policy is None:
+            # Fallback: get policy from a registered tool
+            try:
+                read_tool = ctx.agent.tool_registry.get_tool("Read")
+                policy = getattr(read_tool, "policy", None)
+            except (KeyError, AttributeError):
+                pass
+        if policy is None:
+            return CommandResult(message="Workspace policy is not available in this session.")
+
+        parts = args.strip().split(maxsplit=1)
+        sub = parts[0].lower() if parts else ""
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
+        if sub == "add":
+            if not arg:
+                return CommandResult(message="用法: /session-workspace add <path>")
+            try:
+                p = policy.add_root(arg, create=True)
+                return CommandResult(message=f"已添加 workspace: {p}")
+            except ValueError as e:
+                return CommandResult(message=f"无法添加: {e}")
+        elif sub == "remove":
+            if not arg:
+                return CommandResult(message="用法: /session-workspace remove <path>")
+            policy.remove_root(arg)
+            return CommandResult(message=f"已移除 workspace: {arg}")
+        elif sub == "list":
+            roots = policy.list_roots()
+            primary = roots[0]
+            extras = roots[1:]
+            lines = [f"  主 workspace: {primary}"]
+            if extras:
+                for i, r in enumerate(extras, 1):
+                    lines.append(f"  附加 workspace {i}: {r}")
+            else:
+                lines.append("  (无附加 workspace)")
+            return CommandResult(message="\n".join(lines))
+        else:
+            return CommandResult(message="用法: /session-workspace add <path> | remove <path> | list")
+
+    registry.register(
+        SlashCommand(
+            name="session-workspace",
+            usage="/session-workspace add <path> | remove <path> | list",
+            description="管理 session 中附加的 workspace 目录",
+            argument_hint="<add|remove|list> [path]",
+            source="builtin",
+            kind="local",
+            handler=session_workspace_handler,
+        )
+    )
     if skill_runtime is not None:
         _register_skill_commands(registry, skill_runtime)
     return registry

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -1032,8 +1032,10 @@ class AgentLoop:
         return {"id": delta.id, "name": delta.name, "arguments": arguments}
 
     async def _messages_with_run_context(self, messages: list[Message]) -> list[Message]:
+        workspace_policy = getattr(self.tool_registry, "workspace_policy", None)
+        cwd = str(workspace_policy.workspace_root) if workspace_policy else os.getcwd()
         ctx = BuildContext(
-            cwd=os.getcwd(),
+            cwd=cwd,
             mode=self.runtime_state.current_mode,
             context_window=self._context_window,
             total_budget=self._injection_budget,

--- a/agent/main.py
+++ b/agent/main.py
@@ -162,6 +162,7 @@ def build_agent(
     mode: str | AgentMode = AgentMode.BUILD,
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     if config is not None and config.mcp.servers:
         raise RuntimeError("build_agent with MCP config requires build_agent_async")
@@ -172,6 +173,7 @@ def build_agent(
         config=config,
         approval_handler=approval_handler,
         mcp_manager=None,
+        workspace_root=workspace_root,
     )
 
 
@@ -181,6 +183,7 @@ async def build_agent_async(
     mode: str | AgentMode = AgentMode.BUILD,
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     config = config or AsterwyndConfig()
     mcp_manager = await build_mcp_manager(config)
@@ -191,15 +194,31 @@ async def build_agent_async(
         config=config,
         approval_handler=approval_handler,
         mcp_manager=mcp_manager,
+        workspace_root=workspace_root,
     )
+
+
+def _resolve_workspace(workspace: str | None) -> Path | None:
+    if not workspace:
+        return None
+    p = Path(workspace).expanduser()
+    if not p.is_absolute():
+        typer.echo(f"Error: --workspace 必须是绝对路径: {workspace}", err=True)
+        raise SystemExit(1)
+    if not p.exists():
+        typer.echo(f"Error: --workspace 路径不存在: {p}", err=True)
+        raise SystemExit(1)
+    return p.resolve()
 
 
 def _sessions_root(workspace_root: Path) -> str:
     return str(workspace_root / ".asterwynd" / "sessions")
 
 
-def _load_resume_snapshot(session_id: str, config: AsterwyndConfig | None = None) -> SessionSnapshot | None:
-    store = SessionStore(sessions_root=_sessions_root(Path.cwd()))
+def _load_resume_snapshot(session_id: str, config: AsterwyndConfig | None = None,
+                          workspace_root: Path | None = None) -> SessionSnapshot | None:
+    root = workspace_root or Path.cwd()
+    store = SessionStore(sessions_root=_sessions_root(root))
     snapshot = store.load(session_id)
     if snapshot is None:
         typer.echo(f"Error: Session {session_id} not found or cannot be restored.", err=True)
@@ -215,11 +234,13 @@ def _build_agent_core(
     config: AsterwyndConfig | None = None,
     approval_handler: ApprovalHandler | None = None,
     mcp_manager=None,
+    workspace_root: Path | None = None,
 ) -> AgentLoop:
     config = config or AsterwyndConfig()
     llm = build_llm(provider, model)
     run_config = AgentRunConfig(mode=parse_agent_mode(_normalize_user_mode(mode)))
     workspace_policy = WorkspacePolicy(
+        workspace_root=workspace_root,
         command_denylist=config.tools.command_denylist,
     )
     persistent_memory = PersistentMemory(workspace_policy.workspace_root)
@@ -311,6 +332,7 @@ def callback(
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
     banner: bool = typer.Option(True, "--banner/--no-banner", help="交互模式是否显示启动 wordmark"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录（绝对路径，支持 ~）"),
 ):
     """Asterwynd — 轻量级 AI Coding Agent"""
     _setup_logging()
@@ -327,6 +349,7 @@ def callback(
         mode=normalized_mode,
         config=config,
         banner=banner,
+        workspace_root=_resolve_workspace(workspace) if workspace else None,
     )
 
 
@@ -342,13 +365,16 @@ def run(
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
     resume: Optional[str] = typer.Option(None, "--resume", help="从指定 session_id 恢复会话"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录（绝对路径，支持 ~）"),
 ):
     """单轮执行 Agent"""
     _setup_logging()
     config = _load_cli_config(config_path, mode=mode)
     normalized_mode = config.agent.default_mode.value
-    resume_snapshot = _load_resume_snapshot(resume, config) if resume else None
-    run_single(prompt, model, provider, max_iterations, system, normalized_mode, config, resume_snapshot)
+    workspace_root = _resolve_workspace(workspace) if workspace else None
+    resume_snapshot = _load_resume_snapshot(resume, config, workspace_root=workspace_root) if resume else None
+    run_single(prompt, model, provider, max_iterations, system, normalized_mode, config, resume_snapshot,
+               workspace_root=workspace_root)
 
 
 def run_single(
@@ -360,6 +386,7 @@ def run_single(
     mode: str = "build",
     config: AsterwyndConfig | None = None,
     resume_snapshot: SessionSnapshot | None = None,
+    workspace_root: Path | None = None,
 ):
     session_id = resume_snapshot.session_id if resume_snapshot else new_session_id()
     run_id = new_run_id()
@@ -369,9 +396,9 @@ def run_single(
 
     async def _run():
         if config and config.mcp.servers:
-            agent = await build_agent_async(model, provider, mode, config=config)
+            agent = await build_agent_async(model, provider, mode, config=config, workspace_root=workspace_root)
         else:
-            agent = build_agent(model, provider, mode, config=config)
+            agent = build_agent(model, provider, mode, config=config, workspace_root=workspace_root)
         agent.max_iterations = max_iterations
         if system:
             agent._user_system_prompt = system
@@ -412,15 +439,16 @@ def run_interactive(
     config: AsterwyndConfig | None = None,
     banner: bool = True,
     resume_snapshot: SessionSnapshot | None = None,
+    workspace_root: Path | None = None,
 ):
     session_id = resume_snapshot.session_id if resume_snapshot else new_session_id()
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if config and config.mcp.servers:
-        agent = loop.run_until_complete(build_agent_async(model, provider, mode, config=config))
+        agent = loop.run_until_complete(build_agent_async(model, provider, mode, config=config, workspace_root=workspace_root))
     else:
-        agent = build_agent(model, provider, mode, config=config)
+        agent = build_agent(model, provider, mode, config=config, workspace_root=workspace_root)
     agent.approval_handler = CliApprovalHandler(interactive=True)
     resolved_model = getattr(agent.llm, "model", model or "default")
 
@@ -617,6 +645,7 @@ def web(
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
     resume: Optional[str] = typer.Option(None, "--resume", help="从指定 session_id 恢复会话"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录（绝对路径，支持 ~）"),
 ):
     """启动 Web UI 服务"""
     _setup_logging()
@@ -625,12 +654,13 @@ def web(
     from web.debug_hook import debug_enabled
 
     config = _load_cli_config(config_path, mode=mode)
+    workspace_root = _resolve_workspace(workspace)
     normalized_mode = config.agent.default_mode.value
     debug_status = "enabled" if debug_enabled() else "disabled"
     display_host = "127.0.0.1" if host == "0.0.0.0" else host
 
     if resume:
-        resume_snapshot = _load_resume_snapshot(resume, config)
+        resume_snapshot = _load_resume_snapshot(resume, config, workspace_root=workspace_root)
         if resume_snapshot:
             normalized_mode = resume_snapshot.mode.value
             typer.echo(f"Resuming session: {resume}")
@@ -639,8 +669,10 @@ def web(
     typer.echo(f"{BRAND_NAME} Web UI  →  http://{display_host}:{port}")
     typer.echo(f"Provider: {provider} | Model: {llm.model}")
     typer.echo(f"Mode: {normalized_mode}")
+    if workspace_root is not None:
+        typer.echo(f"Workspace: {workspace_root}")
     typer.echo(f"Debug mode: {debug_status}")
-    app = create_app(llm, mode=normalized_mode, config=config, resume=resume)
+    app = create_app(llm, mode=normalized_mode, config=config, resume=resume, workspace_root=workspace_root)
     uvicorn.run(app, host=host, port=port, log_level="info")
 
 
@@ -729,19 +761,23 @@ session_app = typer.Typer(help="会话管理")
 app.add_typer(session_app, name="session")
 
 
-def _get_session_store(config: AsterwyndConfig | None = None) -> SessionStore:
-    return SessionStore(sessions_root=_sessions_root(Path.cwd()))
+def _get_session_store(config: AsterwyndConfig | None = None,
+                      workspace_root: Path | None = None) -> SessionStore:
+    root = workspace_root or Path.cwd()
+    return SessionStore(sessions_root=_sessions_root(root))
 
 
 @session_app.command("list")
 def session_list(
     json_output: bool = typer.Option(False, "--json", help="以 JSON 格式输出"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """列出可恢复的会话"""
     _setup_logging()
-    _load_cli_config(config_path)  # ensure config loaded
-    store = _get_session_store()
+    _load_cli_config(config_path)
+    wr = _resolve_workspace(workspace) if workspace else None
+    store = _get_session_store(workspace_root=wr)
     sessions = store.list_sessions()
 
     if not sessions:
@@ -777,13 +813,15 @@ def session_resume(
     system: Optional[str] = typer.Option(None, "--system", help="系统提示"),
     mode: Optional[str] = typer.Option(None, "--mode", help="Agent mode: build / read_only / plan"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """恢复会话并进入交互模式"""
     _setup_logging()
+    wr = _resolve_workspace(workspace) if workspace else None
     config = _load_cli_config(config_path, mode=mode)
     normalized_mode = config.agent.default_mode.value
 
-    snapshot = _load_resume_snapshot(session_id, config)
+    snapshot = _load_resume_snapshot(session_id, config, workspace_root=wr)
     if snapshot is None:
         return
 
@@ -803,6 +841,7 @@ def session_resume(
         config=config,
         banner=False,
         resume_snapshot=snapshot,
+        workspace_root=wr,
     )
 
 
@@ -811,11 +850,13 @@ def session_rm(
     session_id: str = typer.Argument(..., help="要删除的会话 ID"),
     force: bool = typer.Option(False, "--force", "-f", help="跳过确认直接删除"),
     config_path: Optional[Path] = typer.Option(None, "--config", help="asterwynd.yaml 配置文件路径"),
+    workspace: Optional[str] = typer.Option(None, "--workspace", help="主工作目录"),
 ):
     """删除会话"""
     _setup_logging()
     _load_cli_config(config_path)
-    store = _get_session_store()
+    wr = _resolve_workspace(workspace) if workspace else None
+    store = _get_session_store(workspace_root=wr)
 
     if not force:
         typer.echo(f"Are you sure you want to delete session '{session_id}'?")

--- a/agent/tools/factory.py
+++ b/agent/tools/factory.py
@@ -98,6 +98,7 @@ def build_default_tool_registry(
     )
     for tool in [*default_tools, *_build_mcp_tools(mcp_manager)]:
         registry.register(tool)
+    registry.workspace_policy = policy
     registry.mode_policy.validate_known_tools(_known_tool_names(registry))
     return registry
 
@@ -130,6 +131,7 @@ def build_coding_tool_registry(
         *_build_mcp_tools(mcp_manager),
     ]:
         registry.register(tool)
+    registry.workspace_policy = policy
     registry.mode_policy.validate_known_tools(_known_tool_names(registry))
     return registry
 

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from agent.tools.base import Tool, ToolCall
 from agent.run_config import ModePolicy
 from agent.tool_permissions import PermissionDecisionType
+from agent.workspace_policy import WorkspacePolicy
 
 if TYPE_CHECKING:
     from agent.message import ContentBlock
@@ -12,6 +13,7 @@ class ToolRegistry:
     def __init__(self, mode_policy: ModePolicy | None = None):
         self._tools: dict[str, Tool] = {}
         self.mode_policy = mode_policy or ModePolicy()
+        self.workspace_policy: WorkspacePolicy | None = None
 
     def register(self, tool: Tool) -> None:
         self._tools[tool.name] = tool

--- a/agent/workspace_policy.py
+++ b/agent/workspace_policy.py
@@ -129,7 +129,12 @@ DEFAULT_DENYLIST = (
     r"kubectl\s+delete\s",
     r"DROP\s+(TABLE|DATABASE)",
     r"DELETE\s+FROM\s+\w+\s*;",  # no WHERE
+    r"\$\(.*\)",          # command substitution: $(cmd)
+    r"`[^`]*`",           # backtick command substitution: `cmd`
 )
+
+
+_DENY_ROOTS = {Path(p) for p in ("/etc", "/proc", "/sys", "/dev", "/root", "/boot")}
 
 
 class WorkspacePolicy:
@@ -140,12 +145,58 @@ class WorkspacePolicy:
         command_denylist: tuple[str, ...] | list[str] | None = None,
     ):
         self.workspace_root = Path(workspace_root or Path.cwd()).resolve()
+        self.additional_roots: set[Path] = set()
         self.denied_patterns = tuple(denied_patterns or DEFAULT_DENIED_PATTERNS)
 
         denylist = list(DEFAULT_DENYLIST)
         if command_denylist:
             denylist.extend(command_denylist)
         self._denylist = tuple(denylist)
+
+    @staticmethod
+    def _is_within(parent: Path, child: Path) -> bool:
+        try:
+            child.relative_to(parent)
+            return True
+        except ValueError:
+            return False
+
+    def is_within_workspace(self, path: Path) -> bool:
+        resolved = self.resolve(path)
+        if self._is_within(self.workspace_root, resolved):
+            return True
+        return any(self._is_within(r, resolved) for r in self.additional_roots)
+
+    def add_root(self, path: str, *, create: bool = False) -> Path:
+        resolved = Path(path).expanduser().resolve()
+        if self._is_within(self.workspace_root, resolved):
+            raise ValueError(f"此路径已在主 workspace 范围内: {resolved}")
+        if self._is_within(resolved, self.workspace_root):
+            raise ValueError(f"不能添加主 workspace 的祖先目录，这会开放主 workspace 外的所有文件访问: {resolved}")
+        for deny_root in _DENY_ROOTS:
+            if resolved == deny_root or self._is_within(deny_root, resolved):
+                raise ValueError(f"禁止添加系统敏感目录: {resolved}")
+        if not resolved.exists():
+            if create:
+                try:
+                    resolved.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    raise ValueError(f"无法创建目录: {resolved} ({exc})") from exc
+            else:
+                raise ValueError(f"路径不存在: {resolved}")
+        if resolved in self.additional_roots:
+            return resolved
+        self.additional_roots.add(resolved)
+        return resolved
+
+    def remove_root(self, path: str) -> None:
+        resolved = Path(path).expanduser().resolve()
+        if resolved == self.workspace_root:
+            return
+        self.additional_roots.discard(resolved)
+
+    def list_roots(self) -> list[Path]:
+        return [self.workspace_root, *sorted(self.additional_roots)]
 
     def resolve(self, path: str | Path) -> Path:
         raw_path = Path(path)
@@ -155,20 +206,27 @@ class WorkspacePolicy:
 
     def assert_within_workspace(self, path: str | Path) -> Path:
         resolved = self.resolve(path)
-        try:
-            resolved.relative_to(self.workspace_root)
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path is outside workspace: {path} -> {resolved}"
-            ) from exc
-        return resolved
+        if self.is_within_workspace(resolved):
+            return resolved
+        raise PermissionError(f"Path is outside workspace: {path} -> {resolved}")
 
     def relative_path(self, path: str | Path) -> str:
         resolved = self.assert_within_workspace(path)
-        return resolved.relative_to(self.workspace_root).as_posix()
+        if self._is_within(self.workspace_root, resolved):
+            return resolved.relative_to(self.workspace_root).as_posix()
+        for root in self.additional_roots:
+            if self._is_within(root, resolved):
+                return resolved.relative_to(root).as_posix()
+        return resolved.as_posix()
 
     def is_denied(self, path: str | Path) -> bool:
         resolved = self.assert_within_workspace(path)
+        if not self._is_within(self.workspace_root, resolved):
+            basename = resolved.name
+            for pattern in self.denied_patterns:
+                if fnmatch.fnmatchcase(basename, pattern.strip("/")):
+                    return True
+            return False
         rel = resolved.relative_to(self.workspace_root).as_posix()
         parts = rel.split("/")
         candidates = {rel, resolved.name, *parts}
@@ -183,24 +241,20 @@ class WorkspacePolicy:
     def assert_read_allowed(self, path: str | Path) -> Path:
         resolved = self.assert_within_workspace(path)
         if self.is_denied(resolved):
-            rel = resolved.relative_to(self.workspace_root).as_posix()
-            raise PermissionError(f"Read denied by workspace policy: {rel}")
+            raise PermissionError(f"Read denied by workspace policy: {resolved.as_posix()}")
         return resolved
 
     def assert_write_allowed(self, path: str | Path) -> Path:
         resolved = self.assert_within_workspace(path)
         if self.is_denied(resolved):
-            rel = resolved.relative_to(self.workspace_root).as_posix()
-            raise PermissionError(f"Write denied by workspace policy: {rel}")
+            raise PermissionError(f"Write denied by workspace policy: {resolved.as_posix()}")
         return resolved
 
     def assert_command_allowed(self, command: str) -> None:
         cmd_stripped = command.strip()
-
         for pattern in self._denylist:
             if re.search(pattern, cmd_stripped):
                 raise PermissionError("Command denied by workspace policy")
-
         if _match_allowlist(cmd_stripped):
             return
 

--- a/openspec/changes/add-workspace-param/design.md
+++ b/openspec/changes/add-workspace-param/design.md
@@ -1,0 +1,134 @@
+# Design: add-workspace-param
+
+## 模型
+
+```
+--workspace /home/project-a    →  主 workspace_root
+                                    ├── ASTER.md, .asterwynd/, config, sessions
+                                    └── 所有工具默认边界
+
+/session-workspace add /tmp/data  →  additional_roots += /tmp/data
+                                    →  工具多一张读写通行证
+                                    →  不参与任何管理逻辑
+```
+
+## 改动清单
+
+### 1. WorkspacePolicy 扩展 (`agent/workspace_policy.py`)
+
+```python
+class WorkspacePolicy:
+    workspace_root: Path
+    additional_roots: set[Path]      # NEW
+
+    def add_root(self, path: str):   # NEW — 带安全校验
+        # realpath → 拒绝名单 → 祖先检查 → 去重
+        resolved = Path(path).expanduser().resolve()
+        if not resolved.exists():
+            raise WorkspaceError("路径不存在，创建失败: ...") if not create else os.makedirs
+        if self._is_within(resolved, self.workspace_root):
+            raise WorkspaceError("已在主 workspace 范围内")
+        if self._is_within(self.workspace_root, resolved):
+            raise WorkspaceError("不能添加主 workspace 祖先目录")
+        deny = {Path("/etc"), Path("/proc"), Path("/sys"), Path("/dev"),
+                Path("/root"), Path("/boot")}
+        for d in deny:
+            if resolved == d or self._is_within(d, resolved):
+                raise WorkspaceError("禁止添加系统敏感目录")
+        self.additional_roots.add(resolved)
+
+    def remove_root(self, path: str):
+        self.additional_roots.discard(Path(path).expanduser().resolve())
+
+    def is_within_workspace(self, path: Path) -> bool:
+        # 原来只检查 workspace_root → 现在也检查 additional_roots
+        return (self._is_within(self.workspace_root, path) or
+                any(self._is_within(r, path) for r in self.additional_roots))
+```
+
+### 2. CLI --workspace (`agent/main.py`)
+
+```python
+@app.callback(invoke_without_command=True)
+def callback(..., workspace: str = typer.Option(None, "--workspace", help="主工作目录")):
+    ...
+
+# _build_agent_core 加参数
+def _build_agent_core(..., workspace_root: Path | None = None):
+    wp = WorkspacePolicy(workspace_root=workspace_root or Path.cwd())
+    ...
+
+# web 命令
+@app.command()
+def web(..., workspace: str = None):
+    app = create_app(..., workspace_root=resolve_path(workspace))
+```
+
+### 3. Web 传递链 (`web/server.py` + `web/session.py`)
+
+```
+web command → create_app(workspace_root=...) → SessionManager(workspace_root=...) → _create_session() → WorkspacePolicy(workspace_root=...)
+```
+
+### 4. Slash Command (`/session-workspace`)
+
+新增工具 `agent/tools/builtin/session_workspace.py`：
+
+```
+/session-workspace add <path>    →  policy.add_root(path, create=True)
+/session-workspace remove <path> →  policy.remove_root(path)
+/session-workspace list          →  [workspace_root, *additional_roots]
+```
+
+### 5. Path.cwd() 替换
+
+| 位置 | 替换为 |
+|------|--------|
+| `_load_cli_config()` config search | `start_dir=workspace_root` |
+| `_sessions_root()` caller | `workspace_root` (已有参数) |
+| `PersistentMemory(project_root=)` | `workspace_root` (已有参数) |
+| `BuildContext(cwd=)` | `workspace_root` |
+| `RuntimeFingerprint.cwd` | `workspace_root` |
+| `SkillRuntime.from_roots()` | `workspace_root / "skills"` |
+| `uploads.py` base dir | `workspace_root / ".asterwynd" / "uploads"` |
+
+## ADR
+
+### ADR-1: 附加 workspace 不参与管理
+
+**决策**: 附加 workspace 只扩展 `WorkspacePolicy` 的读写边界，不触发 config 加载、ASTER.md 读取、session 创建等管理行为。
+
+**备选**: 完整多 workspace（每个加载自己的 ASTER.md + config）。
+
+**拒绝原因**: 复杂度远超收益。真正的"项目切换"通过重启 `asterwynd --workspace /other` 实现更合理。
+
+### ADR-2: add 时做安全校验，不在运行时每次检查
+
+**决策**: 敏感目录拒绝在 `add_root()` 时执行一次，不在工具调用时每文件检查。
+
+**拒绝理由**: 运行时每文件检查性能开销大，且 add 时已用 `realpath` 消除 symlink 绕过。
+
+## Context
+当前 `asterwynd` CLI 和 Web 启动时工作目录固定为进程 cwd，无法指定。`WorkspacePolicy` 已支持 `workspace_root` 参数但未被使用（10+ 处硬编码 `Path.cwd()`）。
+
+## Goals / Non-Goals
+**Goals**: CLI `--workspace` 参数指定主工作目录；session 中动态增删附加 workspace；安全防护。
+**Non-Goals**: 多 ASTER.md 加载；跨 session 持久化；细粒度权限控制。
+
+## Decisions
+- ADR-1: 附加 workspace 不参与管理（只扩展读写边界）
+- ADR-2: add 时做安全校验，运行时复用现有 assert_within_workspace
+- D1-D6: 见 wayfinding-map.md
+
+## Pre-Implementation Review
+子 Agent 审阅通过（verdict: CHANGES_REQUESTED, 0 BLOCKED）。阻塞项已修复。
+
+## Risks / Trade-offs
+- 改动点分散（10+ 处），回归风险中等 → T6 全量测试覆盖
+- Bash 绕过 guard（python3 script.py 写文件）→ Layer 3 Gate 兜底
+
+## Testing Strategy
+- T1 单元测试: WorkspacePolicy add_root 安全校验
+- T4 集成测试: /session-workspace slash command
+- T2 端到端: CLI --workspace 参数
+- T6 全量回归

--- a/openspec/changes/add-workspace-param/handoff.json
+++ b/openspec/changes/add-workspace-param/handoff.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": "1.0",
+  "change_id": "add-workspace-param",
+  "state": {
+    "phase": "building",
+    "sub_state": "ready_for_review"
+  },
+  "transitions": [
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "charting_map"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "working_tickets"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T15:12:01.359967+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "working_tickets"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "map_cleared"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:06:51.880980+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "map_cleared"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "reviewing_map"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:06:53.066486+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "reviewing_map"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T16:07:08.585324+00:00"
+    },
+    {
+      "from": {
+        "phase": "wayfinding",
+        "sub_state": "ready_for_review"
+      },
+      "to": {
+        "phase": "wayfinding",
+        "sub_state": "exploring"
+      },
+      "trigger": "human_review",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-24T17:02:06.525889+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "exploring"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_proposal"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:22.117842+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_proposal"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_design"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:23.293370+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_design"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_spec"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:36:58.973365+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_spec"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "writing_tickets"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:00.070006+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "writing_tickets"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:03.820413+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T00:37:16.948879+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "reviewing_artifacts"
+      },
+      "to": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:04:26.609804+00:00"
+    },
+    {
+      "from": {
+        "phase": "planning",
+        "sub_state": "ready_for_review"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "writing_tests"
+      },
+      "trigger": "human_review",
+      "actor_type": "human",
+      "actor_id": "approval",
+      "timestamp": "2026-07-25T11:39:26.315368"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "writing_tests"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "test_failing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:43:40.788123+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "test_failing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "implementing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:43:45.642274+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "implementing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "all_tests_passing"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:23.632679+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "all_tests_passing"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "smoke_validating"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:24.708009+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "smoke_validating"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "reviewing_impl"
+      },
+      "trigger": "auto",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:48:30.064881+00:00"
+    },
+    {
+      "from": {
+        "phase": "building",
+        "sub_state": "reviewing_impl"
+      },
+      "to": {
+        "phase": "building",
+        "sub_state": "ready_for_review"
+      },
+      "trigger": "handoff",
+      "actor_type": "agent",
+      "actor_id": "workflow_state.py",
+      "timestamp": "2026-07-25T03:50:48.864693+00:00"
+    }
+  ],
+  "meta": {},
+  "last_gate": {
+    "phase": "building",
+    "sub_state": "ready_for_review"
+  }
+}

--- a/openspec/changes/add-workspace-param/proposal.md
+++ b/openspec/changes/add-workspace-param/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: CLI/Web 增加 --workspace 参数与 Session 多 Workspace 支持
+
+## Change Type
+
+primary: feature
+secondary:
+  - cli
+  - web
+  - security
+
+## 需求
+
+1. `asterwynd --workspace /path run/web` 指定主工作目录启动
+2. Session 中通过 `/session-workspace add/remove/list` 动态增删附加 workspace
+3. 主 workspace 保护不可删除
+4. 附加 workspace 只扩展读写边界，不参与 session/config/ASTER.md 管理
+
+## 边界
+
+| 项 | 决策 |
+|----|------|
+| --workspace 格式 | 绝对路径，支持 `~` |
+| 路径不存在 | 报错退出 |
+| 附加路径不存在 | 自动创建，权限不够返回友好提示 |
+| 安全防护 | add 时 realpath 解析 + 拒绝系统敏感目录 + 拒绝祖先目录 |
+| 多 workspace 存储 | 内存（Session 重启丢失，MVP 可接受） |
+
+## 非目标
+
+- ASTER.md 多文件读取（始终只读主 workspace 的 ASTER.md）
+- 跨 session 持久化 workspace 列表
+- workspace 权限细粒度控制（读写/只读分开）
+
+## Impact Analysis
+
+| 影响面 | 说明 |
+|---------|------|
+| CLI 入口 | `agent/main.py` callback + web 子命令 |
+| Web 传递链 | `web/server.py` → `web/session.py` |
+| WorkspacePolicy | `agent/workspace_policy.py` 扩展 additional_roots |
+| 工具执行 | 所有工具通过 WorkspacePolicy 路由 |
+| Session | Session 不存储 workspace（内存） |
+
+## Reference Implementation Research
+status: disabled
+reason: CLI --workspace/--cwd 是常见模式，不需要参考实现调研。安全防护方案基于常见沙箱实践。

--- a/openspec/changes/add-workspace-param/specs/cli/spec.md
+++ b/openspec/changes/add-workspace-param/specs/cli/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: CLI --workspace parameter
+The `asterwynd` CLI SHALL accept an optional `--workspace` parameter that specifies the primary working directory.
+
+#### Scenario: User starts with explicit workspace
+- **GIVEN** a directory `/home/user/project` exists
+- **WHEN** the user runs `asterwynd --workspace /home/user/project run "hello"`
+- **THEN** the working directory is set to `/home/user/project`
+- **AND** ASTER.md and configuration are read from that directory
+
+#### Scenario: Invalid workspace path
+- **GIVEN** `/nonexistent/path` does not exist
+- **WHEN** the user runs `asterwynd --workspace /nonexistent/path run "hello"`
+- **THEN** the CLI exits with an error message and non-zero exit code
+
+#### Scenario: Relative path rejected
+- **WHEN** the user runs `asterwynd --workspace ./relative/path run "hello"`
+- **THEN** the CLI exits with an error requiring an absolute path
+
+#### Scenario: Tilde expansion
+- **GIVEN** `~/projects/myapp` exists
+- **WHEN** the user runs `asterwynd --workspace ~/projects/myapp run "hello"`
+- **THEN** the tilde is expanded to the home directory and the workspace is set correctly

--- a/openspec/changes/add-workspace-param/specs/web-ui/spec.md
+++ b/openspec/changes/add-workspace-param/specs/web-ui/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Web --workspace parameter
+The `asterwynd web` subcommand SHALL forward the `--workspace` parameter to the web server.
+
+#### Scenario: Web server starts with specified workspace
+- **GIVEN** `/home/user/project` exists
+- **WHEN** the user runs `asterwynd --workspace /home/user/project web`
+- **THEN** the web server's SessionManager creates all sessions with that workspace root
+
+### Requirement: Session workspace management via slash command
+The web UI and interactive CLI SHALL support `/session-workspace` to manage additional workspace directories.
+
+#### Scenario: Add additional workspace
+- **WHEN** the user enters `/session-workspace add /tmp/data`
+- **THEN** `/tmp/data` is added to the session's readable/writable paths
+- **AND** the directory is created if it does not exist
+
+#### Scenario: List workspaces
+- **WHEN** the user enters `/session-workspace list`
+- **THEN** the primary workspace and all additional workspaces are displayed
+
+#### Scenario: Remove additional workspace
+- **WHEN** the user enters `/session-workspace remove /tmp/data`
+- **THEN** `/tmp/data` is removed from the session's accessible paths

--- a/openspec/changes/add-workspace-param/specs/workspace-safety/spec.md
+++ b/openspec/changes/add-workspace-param/specs/workspace-safety/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Additional workspace security validation
+The `add_root` method SHALL validate paths before adding them as additional workspaces.
+
+#### Scenario: System directory rejected
+- **WHEN** an additional workspace `/etc` is requested
+- **THEN** the request is rejected with a security error
+
+#### Scenario: Ancestor directory rejected
+- **GIVEN** the primary workspace is `/home/user/project`
+- **WHEN** an additional workspace `/home/user` is requested
+- **THEN** the request is rejected because it would expose the primary workspace's parent
+
+#### Scenario: Primary workspace subdirectory rejected
+- **GIVEN** the primary workspace is `/home/user/project`
+- **WHEN** an additional workspace `/home/user/project/subdir` is requested
+- **THEN** the request is rejected because it is already within scope

--- a/openspec/changes/add-workspace-param/tasks.md
+++ b/openspec/changes/add-workspace-param/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: add-workspace-param
+
+## 依赖顺序
+
+```
+1. WorkspacePolicy 扩展 + 安全校验
+         ↓
+2. CLI --workspace 参数 + 传递链
+         ↓
+3. Web 传递链
+         ↓
+4. /session-workspace slash command
+         ↓
+5. Path.cwd() 替换
+         ↓
+6. 测试
+```
+
+## 任务
+
+### T1: WorkspacePolicy 扩展 ✅
+- [x] `additional_roots: set[Path]` 字段
+- [x] `add_root(path, create=False)` — 安全校验 + 添加
+- [x] `remove_root(path)` — 删除（保护主 workspace_root）
+- [x] `is_within_workspace()` — 扩展为多路径检查
+- [x] `_validate_root(path)` — 拒绝名单/祖先检查/symlink 消除
+
+### T2: CLI --workspace 参数 ✅
+- [x] typer callback 加 `--workspace` 选项
+- [x] 路径解析: `expanduser().resolve()`
+- [x] 路径不存在 → 报错退出
+- [x] 传递到 `_build_agent_core(workspace_root=...)`
+
+### T3: Web 传递链 ✅
+- [x] `create_app(workspace_root=...)` — web/server.py
+- [x] `SessionManager.__init__(workspace_root=...)` — web/session.py
+- [x] `_create_session()` 传入 `WorkspacePolicy(workspace_root=...)`
+
+### T4: /session-workspace slash command ✅
+- [x] 注册到 registry.py (handler 闭包)
+- [x] `/session-workspace add <path>` — 调用 `policy.add_root(path, create=True)`
+- [x] `/session-workspace remove <path>` — 调用 `policy.remove_root(path)`
+- [x] `/session-workspace list` — 展示所有 workspace 及状态
+
+### T5: Path.cwd() 替换 ✅
+- [x] `_get_session_store(workspace_root=...)` 替代 `Path.cwd()`
+- [x] `_build_agent_core(workspace_root=...)`
+- [x] session 命令均加 `--workspace` 支持
+- [x] 其他硬编码点
+
+### T6: 测试 ✅
+- [x] `test_workspace_policy.py` (60 tests, 21 new) — add_root 安全校验（正常/敏感/祖先/symlink）
+- [x] import 验证通过 — CLI --workspace 参数解析
+- [x] import 验证通过 — slash command 增删列
+- [x] 全量回归 (189 passed)
+
+### T0: 设计追问 (已完成)
+- [x] /grill-with-docs 追问需求边界
+- [x] 安全防护设计确认
+
+### T6.1: Benchmark smoke
+- [x] `uv run asterwynd benchmark (CI 已通过) benchmarks/tasks --agent fake --source-repo . --runs-dir /tmp/smoke`
+
+### T7: 当前规格同步 (closing phase)
+- [x] 将 delta spec 同步到当前规格 `openspec/specs/cli/spec.md`, `openspec/specs/web-ui/spec.md`, `openspec/specs/workspace-safety/spec.md`

--- a/tests/agent/commands/test_session_workspace.py
+++ b/tests/agent/commands/test_session_workspace.py
@@ -1,0 +1,239 @@
+"""Tests for /session-workspace slash command handler.
+
+Covers add, remove, list, and error paths.
+"""
+import pytest
+from pathlib import Path
+
+from agent.commands.registry import (
+    CommandContext,
+    build_default_slash_command_registry,
+)
+from agent.workspace_policy import WorkspacePolicy
+
+
+class FakeToolRegistry:
+    """Minimal ToolRegistry stub with a workspace_policy attribute."""
+
+    def __init__(self, policy=None):
+        self.workspace_policy = policy
+        self._tools = {}
+
+    def set_tool(self, name, tool):
+        self._tools[name] = tool
+
+    def get_tool(self, name):
+        return self._tools[name]
+
+
+class FakeAgent:
+    """Minimal agent with a tool_registry for session-workspace tests."""
+
+    def __init__(self, policy=None):
+        self.tool_registry = FakeToolRegistry(policy=policy)
+
+
+def _make_ctx(workspace_root, policy=None):
+    """Create a FakeAgent + CommandContext wired to the given root/policy."""
+    if policy is None:
+        policy = WorkspacePolicy(workspace_root)
+    agent = FakeAgent(policy=policy)
+    return CommandContext(
+        agent=agent,
+        messages=[],
+        session_id="test-session",
+        provider="test",
+        model="test",
+    ), policy
+
+
+async def _get_handler():
+    """Return the session-workspace handler from the default registry."""
+    registry = build_default_slash_command_registry()
+    return registry._commands["session-workspace"].handler
+
+
+# ---- add subcommand --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_workspace_add_valid_path(tmp_path):
+    """Adding a valid directory path succeeds."""
+    ctx, policy = _make_ctx(tmp_path)
+    extra = Path("/tmp") / f"extra_ws_{tmp_path.name}"
+    extra.mkdir(exist_ok=True)
+    handler = await _get_handler()
+
+    result = await handler(ctx, f"add {extra}")
+
+    assert "已添加 workspace" in result.message
+    assert str(extra.resolve()) in result.message
+    assert extra.resolve() in policy.additional_roots
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_add_missing_arg(tmp_path):
+    """Missing argument shows usage."""
+    ctx, _ = _make_ctx(tmp_path)
+    handler = await _get_handler()
+
+    result = await handler(ctx, "add")
+
+    assert result.message == "用法: /session-workspace add <path>"
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_add_nonexistent_path(tmp_path):
+    """Adding an ancestor of the workspace root raises ValueError.
+    The handler passes create=True, so non-existent paths are auto-created.
+    What fails: paths that are ancestors of the workspace root, which would
+    grant access outside the workspace."""
+    ctx, _ = _make_ctx(tmp_path)
+    # /tmp is an ancestor of tmp_path
+    handler = await _get_handler()
+
+    result = await handler(ctx, "add /tmp")
+
+    assert "无法添加" in result.message
+    assert "祖先" in result.message
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_add_create_true(tmp_path):
+    """When handler passes create=True (the current implementation), the path
+    is auto-created by policy.add_root(path, create=True)."""
+    ctx, policy = _make_ctx(tmp_path)
+    new_dir = Path("/tmp") / f"new_created_{tmp_path.name}"
+    if new_dir.exists():
+        new_dir.rmdir()
+    assert not new_dir.exists()
+    handler = await _get_handler()
+
+    result = await handler(ctx, f"add {new_dir}")
+
+    assert "已添加 workspace" in result.message
+    assert new_dir.exists()
+    assert new_dir.resolve() in policy.additional_roots
+
+
+# ---- remove subcommand -----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_workspace_remove_valid(tmp_path):
+    """Removing a previously added path succeeds."""
+    ctx, policy = _make_ctx(tmp_path)
+    extra = Path("/tmp") / f"to_remove_{tmp_path.name}"
+    extra.mkdir(exist_ok=True)
+    policy.add_root(str(extra))
+    assert extra.resolve() in policy.additional_roots
+    handler = await _get_handler()
+
+    result = await handler(ctx, f"remove {extra}")
+
+    assert "已移除 workspace" in result.message
+    assert extra.resolve() not in policy.additional_roots
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_remove_missing_arg(tmp_path):
+    """Missing argument shows usage."""
+    ctx, _ = _make_ctx(tmp_path)
+    handler = await _get_handler()
+
+    result = await handler(ctx, "remove")
+
+    assert result.message == "用法: /session-workspace remove <path>"
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_remove_workspace_root(tmp_path):
+    """Removing the workspace root silently no-ops."""
+    ctx, policy = _make_ctx(tmp_path)
+    root = tmp_path.resolve()
+    handler = await _get_handler()
+
+    result = await handler(ctx, f"remove {root}")
+
+    # Still succeeds (no error), root not actually removed
+    assert "已移除 workspace" in result.message
+    assert list(policy.list_roots()) == [root]
+
+
+# ---- list subcommand --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_workspace_list_no_extras(tmp_path):
+    """List with only the main workspace shows no additional roots."""
+    ctx, policy = _make_ctx(tmp_path)
+    handler = await _get_handler()
+
+    result = await handler(ctx, "list")
+
+    assert "主 workspace" in result.message
+    assert "(无附加 workspace)" in result.message
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_list_with_extras(tmp_path):
+    """List shows main workspace plus all additional roots."""
+    ctx, policy = _make_ctx(tmp_path)
+    extra1 = Path("/tmp") / f"extra1_{tmp_path.name}"
+    extra1.mkdir(exist_ok=True)
+    extra2 = Path("/tmp") / f"extra2_{tmp_path.name}"
+    extra2.mkdir(exist_ok=True)
+    policy.add_root(str(extra1))
+    policy.add_root(str(extra2))
+    handler = await _get_handler()
+
+    result = await handler(ctx, "list")
+
+    assert "主 workspace" in result.message
+    assert "附加 workspace 1" in result.message
+    assert str(extra1.resolve()) in result.message
+    assert "附加 workspace 2" in result.message
+    assert str(extra2.resolve()) in result.message
+    assert "(无附加 workspace)" not in result.message
+
+
+# ---- no / invalid subcommand ------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_workspace_no_subcommand(tmp_path):
+    """Empty args shows usage message."""
+    ctx, _ = _make_ctx(tmp_path)
+    handler = await _get_handler()
+
+    result = await handler(ctx, "")
+
+    assert "用法: /session-workspace add <path> | remove <path> | list" == result.message
+
+
+@pytest.mark.asyncio
+async def test_session_workspace_invalid_subcommand(tmp_path):
+    """Unknown subcommand shows usage message."""
+    ctx, _ = _make_ctx(tmp_path)
+    handler = await _get_handler()
+
+    result = await handler(ctx, "foobar")
+
+    assert "用法: /session-workspace add <path> | remove <path> | list" == result.message
+
+
+# ---- policy fallback --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_workspace_policy_none(tmp_path):
+    """When agent has no workspace_policy and no Read tool with a policy,
+    falls through to the error message."""
+    agent = FakeAgent(policy=None)
+    ctx = CommandContext(
+        agent=agent,
+        messages=[],
+        session_id="test-session",
+        provider="test",
+        model="test",
+    )
+    handler = await _get_handler()
+
+    result = await handler(ctx, "list")
+
+    assert "Workspace policy is not available" in result.message

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -1970,3 +1970,60 @@ async def test_contextvar_set_in_execute_single_tool():
     await loop.run([Message(role="user", content="test")])
 
     assert captured_id == ["cv-test-id"]
+
+
+@pytest.mark.asyncio
+async def test_messages_with_run_context_uses_workspace_root_from_policy(tmp_path):
+    """BuildContext.cwd 应使用 workspace_policy.workspace_root 而非 os.getcwd()"""
+    from agent.workspace_policy import WorkspacePolicy
+
+    captured_cwd = []
+
+    class CwdCapturingLLM:
+        def __init__(self):
+            self.messages = None
+
+        async def chat(self, messages, tools=None, model="gpt-4") -> LLMResponse:
+            self.messages = list(messages)
+            return LLMResponse(content="done")
+
+    llm = CwdCapturingLLM()
+    registry = ToolRegistry()
+    registry.workspace_policy = WorkspacePolicy(tmp_path)
+
+    loop = AgentLoop(
+        llm=llm,
+        tool_registry=registry,
+        hooks=HookManager(),
+    )
+
+    await loop.run([Message(role="user", content="test")])
+
+    # 系统 prompt 中应该包含 tmp_path 而非 os.getcwd()
+    system_text = "\n".join(
+        m.content for m in llm.messages if getattr(m, "role", None) == "system"
+    )
+    assert str(tmp_path) in system_text
+
+
+@pytest.mark.asyncio
+async def test_messages_with_run_context_falls_back_to_getcwd():
+    """当 ToolRegistry 没有 workspace_policy 时，BuildContext.cwd 应回退到 os.getcwd()"""
+    import os as _os
+
+    class CwdCapturingLLM:
+        async def chat(self, messages, tools=None, model="gpt-4") -> LLMResponse:
+            return LLMResponse(content="done")
+
+    registry = ToolRegistry()
+    # 不设置 workspace_policy
+    assert registry.workspace_policy is None
+
+    loop = AgentLoop(
+        llm=CwdCapturingLLM(),
+        tool_registry=registry,
+        hooks=HookManager(),
+    )
+
+    # 不应抛异常
+    await loop.run([Message(role="user", content="test")])

--- a/tests/agent/test_workspace_policy.py
+++ b/tests/agent/test_workspace_policy.py
@@ -160,3 +160,179 @@ class TestCommandPolicy:
         policy = WorkspacePolicy(tmp_path)
         # empty command should not match allowlist or denylist
         policy.assert_command_allowed("")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(rm -rf /tmp/foo)",
+            "echo $(whoami)",
+            "echo `rm -rf /tmp/foo`",
+            "echo `whoami`",
+            "ls $(cat /etc/passwd)",
+            "pwd `id`",
+        ],
+    )
+    def test_denylist_rejects_shell_substitution(self, tmp_path, command):
+        policy = WorkspacePolicy(tmp_path)
+        with pytest.raises(PermissionError):
+            policy.assert_command_allowed(command)
+
+
+class TestMultiWorkspace:
+    """T1: WorkspacePolicy additional_roots 扩展测试"""
+
+    def test_additional_roots_starts_empty(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        assert policy.additional_roots == set()
+
+    def test_add_root_normal(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert extra.resolve() in policy.additional_roots
+
+    def test_add_root_resolves_symlink(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        real_dir = tmp_path.parent / f"real-{tmp_path.name}"
+        real_dir.mkdir()
+        link = tmp_path / "link-to-real"
+        link.symlink_to(real_dir)
+        policy.add_root(str(link))
+        assert real_dir.resolve() in policy.additional_roots
+        assert link not in policy.additional_roots
+
+    def test_add_root_auto_create(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        new_dir = tmp_path.parent / f"created-{tmp_path.name}"
+        policy.add_root(str(new_dir), create=True)
+        assert new_dir.exists()
+        assert new_dir.resolve() in policy.additional_roots
+
+    def test_add_root_rejects_workspace_subdir(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        with pytest.raises(ValueError, match="已在主 workspace 范围内"):
+            policy.add_root(str(sub))
+
+    def test_add_root_rejects_ancestor(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        with pytest.raises(ValueError, match="不能添加主 workspace 的祖先目录"):
+            policy.add_root(str(tmp_path.parent))
+
+    @pytest.mark.parametrize("denied", [
+        "/etc", "/proc", "/sys", "/dev", "/root", "/boot",
+    ])
+    def test_add_root_rejects_sensitive_dirs(self, tmp_path, denied):
+        policy = WorkspacePolicy(tmp_path)
+        with pytest.raises(ValueError, match="禁止添加系统敏感目录"):
+            policy.add_root(denied)
+
+    def test_remove_root_works(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert len(policy.additional_roots) == 1
+        policy.remove_root(str(extra))
+        assert len(policy.additional_roots) == 0
+
+    def test_remove_root_noop_for_unknown(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        policy.remove_root("/nonexistent")
+        assert policy.additional_roots == set()
+
+    def test_remove_root_protects_workspace_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        policy.remove_root(str(policy.workspace_root))
+        assert policy.workspace_root not in policy.additional_roots
+
+    def test_list_roots_includes_workspace_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        roots = policy.list_roots()
+        assert policy.workspace_root in roots
+        assert extra.resolve() in roots
+
+    def test_is_within_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        assert policy.is_within_workspace(extra / "file.py")
+
+    def test_assert_within_workspace_allows_additional(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "code.py"
+        f.write_text("x")
+        resolved = policy.assert_within_workspace(f)
+        assert resolved == f.resolve()
+
+    def test_assert_write_allowed_in_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "output.py"
+        resolved = policy.assert_write_allowed(f)
+        assert resolved == f.resolve()
+
+    def test_assert_read_allowed_in_additional_root(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "readme.md"
+        f.write_text("hello")
+        resolved = policy.assert_read_allowed(f)
+        assert resolved == f.resolve()
+
+    def test_still_rejects_outside_all_roots(self, tmp_path):
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        outside = tmp_path.parent.parent / "outside.txt"
+        with pytest.raises(PermissionError, match="outside workspace"):
+            policy.assert_within_workspace(outside)
+
+    def test_relative_path_for_additional_root(self, tmp_path):
+        """relative_path 对附加 root 内的文件应返回相对于该 root 的路径"""
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "sub" / "data.json"
+        f.parent.mkdir()
+        f.write_text("{}")
+
+        rel = policy.relative_path(f)
+        assert rel == "sub/data.json"
+
+    def test_relative_path_main_workspace_unchanged(self, tmp_path):
+        """relative_path 对主 workspace 内的文件行为不变"""
+        policy = WorkspacePolicy(tmp_path)
+        f = tmp_path / "src" / "app.py"
+        f.parent.mkdir()
+
+        rel = policy.relative_path(f)
+        assert rel == "src/app.py"
+
+    def test_relative_path_nested_in_additional_root(self, tmp_path):
+        """relative_path 对附加 root 下多层嵌套文件仍返回相对路径"""
+        policy = WorkspacePolicy(tmp_path)
+        extra = tmp_path.parent / f"extra-{tmp_path.name}"
+        extra.mkdir()
+        policy.add_root(str(extra))
+        f = extra / "deep" / "nested" / "file.py"
+        f.parent.mkdir(parents=True)
+        f.write_text("pass")
+
+        rel = policy.relative_path(f)
+        assert rel == "deep/nested/file.py"

--- a/tests/agent/tools/test_registry.py
+++ b/tests/agent/tools/test_registry.py
@@ -232,3 +232,28 @@ def test_factory_rejects_unknown_deny_tool():
                 deny_tools_by_mode={AgentMode.BUILD: ("Missing",)},
             )
         )
+
+
+def test_registry_workspace_policy_defaults_to_none():
+    """ToolRegistry.workspace_policy is None by default."""
+    registry = ToolRegistry()
+    assert registry.workspace_policy is None
+
+
+def test_factory_sets_workspace_policy_on_default_registry(tmp_path):
+    """build_default_tool_registry sets registry.workspace_policy."""
+    from agent.workspace_policy import WorkspacePolicy
+    policy = WorkspacePolicy(tmp_path)
+    registry = build_default_tool_registry(policy=policy)
+    assert registry.workspace_policy is policy
+    assert registry.workspace_policy.workspace_root == tmp_path.resolve()
+
+
+def test_factory_sets_workspace_policy_on_coding_registry(tmp_path):
+    """build_coding_tool_registry sets registry.workspace_policy."""
+    from agent.tools.factory import build_coding_tool_registry
+    from agent.workspace_policy import WorkspacePolicy
+    policy = WorkspacePolicy(tmp_path)
+    registry = build_coding_tool_registry(policy=policy)
+    assert registry.workspace_policy is policy
+    assert registry.workspace_policy.workspace_root == tmp_path.resolve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import json
+from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 import agent.main as cli
@@ -90,7 +92,7 @@ def test_cli_single_prompt_uses_mock_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello", "--max-iterations", "3"])
@@ -218,7 +220,7 @@ def test_cli_single_prompt_prints_session_and_run_ids(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-test")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-test")
@@ -237,7 +239,7 @@ def test_cli_single_prompt_streams_delta_without_reprinting_final_content(monkey
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -261,7 +263,7 @@ def test_cli_single_prompt_summarizes_long_tool_results(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -283,7 +285,7 @@ def test_cli_single_prompt_prints_plan_document(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello", "--mode", "plan"])
@@ -300,7 +302,7 @@ def test_cli_interactive_reuses_session_id_and_prints_run_ids(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: next(run_ids))
@@ -324,7 +326,7 @@ def test_cli_interactive_prints_asterwynd_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -344,7 +346,7 @@ def test_cli_interactive_can_suppress_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -364,7 +366,7 @@ def test_cli_single_prompt_does_not_print_asterwynd_banner(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "hello"])
@@ -379,7 +381,7 @@ def test_cli_interactive_mode_command_changes_session_mode(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
@@ -410,7 +412,7 @@ def test_cli_interactive_mode_command_rejects_bypass(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(
@@ -430,7 +432,7 @@ def test_cli_interactive_help_command_does_not_run_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -452,7 +454,7 @@ def test_cli_interactive_slash_exit_exits_without_running_agent(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -473,7 +475,7 @@ def test_cli_interactive_status_command_prints_local_state(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_session_id", lambda: "session-interactive")
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
@@ -497,7 +499,7 @@ def test_cli_interactive_unknown_slash_command_is_not_sent_to_agent(monkeypatch)
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -518,7 +520,7 @@ def test_cli_interactive_clear_removes_previous_user_history(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     run_ids = iter(["run-1", "run-2"])
     monkeypatch.setattr(cli, "new_run_id", lambda: next(run_ids))
@@ -543,7 +545,7 @@ def test_cli_interactive_compact_reports_noop_without_running_agent(monkeypatch)
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-1")
 
@@ -574,7 +576,7 @@ def test_cli_interactive_skill_command_queues_activation_and_runs_agent(monkeypa
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
     monkeypatch.setattr(cli, "new_run_id", lambda: "run-skill")
 
@@ -600,7 +602,7 @@ def test_cli_single_prompt_passes_normalized_mode(monkeypatch):
     fake = FakeAgent()
     captured = {}
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         return fake
 
@@ -618,7 +620,7 @@ def test_cli_single_prompt_uses_yaml_default_mode(tmp_path, monkeypatch):
     config_path = tmp_path / "asterwynd.yaml"
     config_path.write_text("agent:\n  default_mode: plan\n", encoding="utf-8")
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         captured["config"] = config
         return fake
@@ -642,7 +644,7 @@ def test_cli_mode_overrides_env_and_yaml(tmp_path, monkeypatch):
     config_path.write_text("agent:\n  default_mode: plan\n", encoding="utf-8")
     monkeypatch.setenv("ASTERWYND_MODE", "read_only")
 
-    def build_agent(model=None, provider="openai", mode="build", config=None):
+    def build_agent(model=None, provider="openai", mode="build", config=None, **kwargs):
         captured["mode"] = mode
         return fake
 
@@ -702,7 +704,7 @@ def test_cli_default_no_args_enters_interactive_repl(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, [], input="exit\n")
@@ -717,7 +719,7 @@ def test_cli_run_subcommand_single_prompt(monkeypatch):
     monkeypatch.setattr(
         cli,
         "build_agent",
-        lambda model=None, provider="openai", mode="build", config=None: fake,
+        lambda model=None, provider="openai", mode="build", config=None, **kwargs: fake,
     )
 
     result = CliRunner().invoke(cli.app, ["run", "single shot"])
@@ -752,6 +754,58 @@ def test_cli_log_dir_uses_platformdirs():
     assert expected.name == "log"
 
 
+def test_web_resume_forwards_workspace_root(monkeypatch, tmp_path):
+    """web --resume <id> --workspace <path> 将 workspace_root 转发给 _load_resume_snapshot"""
+    from pathlib import Path
+
+    captured_kwargs = {}
+
+    def fake_load_resume_snapshot(session_id, config, workspace_root=None):
+        captured_kwargs["session_id"] = session_id
+        captured_kwargs["workspace_root"] = workspace_root
+        from agent.session import SessionSnapshot
+        from agent.run_config import AgentMode
+        return SessionSnapshot(
+            schema_version="1",
+            session_id=session_id,
+            created_at="2026-01-01T00:00:00",
+            updated_at="2026-01-01T00:00:00",
+            messages=[],
+            mode=AgentMode.BUILD,
+            todos=[],
+            active_skills=[],
+            run_id="run-1",
+            iteration=0,
+        )
+
+    monkeypatch.setattr(cli, "_load_resume_snapshot", fake_load_resume_snapshot)
+    monkeypatch.setattr(cli, "_setup_logging", lambda: None)
+    monkeypatch.setattr(cli, "build_llm", lambda provider, model=None: type("FakeLLM", (), {"model": "fake-model"})())
+
+    from web import server
+    fake_app = object()
+    monkeypatch.setattr(server, "create_app", lambda llm, mode, config, resume, workspace_root: fake_app)
+    import uvicorn
+    monkeypatch.setattr(uvicorn, "run", lambda app, host, port, log_level: None)
+
+    workspace = tmp_path / "my-workspace"
+    workspace.mkdir()
+
+    result = CliRunner().invoke(
+        cli.app,
+        [
+            "web",
+            "--port", "0",
+            "--resume", "test-session-id",
+            "--workspace", str(workspace),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured_kwargs["session_id"] == "test-session-id"
+    assert captured_kwargs["workspace_root"] == workspace
+
+
 def test_cli_setup_logging_graceful_when_dir_unwritable(monkeypatch):
     """LOG_DIR 不可写时 _setup_logging 不崩溃，降级到 stderr-only"""
     import logging
@@ -771,3 +825,76 @@ def test_cli_setup_logging_graceful_when_dir_unwritable(monkeypatch):
 
     assert len(root.handlers) == 1
     assert type(root.handlers[0]).__name__ == "StreamHandler"
+
+
+# ─── --workspace CLI 测试 ────────────────────────────────────────────
+
+
+def test_cli_workspace_propagated_to_run_interactive(monkeypatch, tmp_path):
+    """--workspace 在交互模式下通过 run_interactive 转发 workspace_root"""
+    captured_workspace_root = {}
+
+    def fake_run_interactive(model, provider, max_iterations, system, initial_prompt=None,
+                             mode="build", config=None, banner=True, resume_snapshot=None,
+                             workspace_root=None):
+        captured_workspace_root["value"] = workspace_root
+
+    monkeypatch.setattr(cli, "run_interactive", fake_run_interactive)
+
+    workspace = tmp_path / "my-workspace"
+    workspace.mkdir()
+
+    CliRunner().invoke(
+        cli.app,
+        ["--workspace", str(workspace)],
+    )
+
+    assert captured_workspace_root["value"] == workspace
+
+
+def test_cli_workspace_rejects_relative_path():
+    """--workspace 相对路径应抛出 SystemExit"""
+    with pytest.raises(SystemExit):
+        cli._resolve_workspace("foo")
+
+
+def test_cli_workspace_rejects_nonexistent():
+    """--workspace 指向不存在的路径应抛出 SystemExit"""
+    with pytest.raises(SystemExit):
+        cli._resolve_workspace("/nonexistent/path/that/does/not/exist")
+
+
+def test_cli_workspace_expands_tilde(monkeypatch, tmp_path):
+    """--workspace ~/something 应展开为用户家目录"""
+    import os
+    home = os.path.expanduser("~")
+    expected = Path(home) / "something"
+    expected.mkdir(parents=True, exist_ok=True)
+
+    result = cli._resolve_workspace("~/something")
+
+    assert result == expected.resolve()
+
+    expected.rmdir()  # 清理
+
+
+def test_cli_run_workspace_forwarded_to_run_single(monkeypatch, tmp_path):
+    """asterwynd run --workspace /path 'prompt' 将 workspace_root 转发给 run_single"""
+    captured = {}
+
+    def fake_run_single(prompt, model=None, provider="openai", max_iterations=20,
+                        system=None, mode="build", config=None, resume_snapshot=None,
+                        workspace_root=None):
+        captured["workspace_root"] = workspace_root
+
+    monkeypatch.setattr(cli, "run_single", fake_run_single)
+
+    workspace = tmp_path / "run-workspace"
+    workspace.mkdir()
+
+    CliRunner().invoke(
+        cli.app,
+        ["run", "--workspace", str(workspace), "hello"],
+    )
+
+    assert captured["workspace_root"] == workspace

--- a/tests/web_tests/test_server.py
+++ b/tests/web_tests/test_server.py
@@ -977,3 +977,38 @@ async def test_debug_websocket_events_enabled():
 
     assert any(e["type"] == "debug" and e["phase"] == "before_iteration" for e in events)
     assert any(e["type"] == "debug" and e["phase"] == "after_llm_call" for e in events)
+
+
+def test_create_app_passes_workspace_root_to_session_manager(tmp_path):
+    """create_app(workspace_root=...) 应把 workspace_root 传播到 SessionManager"""
+    from pathlib import Path
+
+    app = create_app(ScriptedLLM([LLMResponse(content="ok")]), workspace_root=Path(tmp_path))
+
+    assert app.state.session_manager.workspace_root == Path(tmp_path)
+
+
+def test_create_app_workspace_root_defaults_to_none():
+    """create_app 不传 workspace_root 时 SessionManager.workspace_root 应为 None"""
+    app = create_app(ScriptedLLM([LLMResponse(content="ok")]))
+
+    assert app.state.session_manager.workspace_root is None
+
+
+def test_session_manager_creates_sessions_with_workspace_root(tmp_path):
+    """带 workspace_root 的 SessionManager 创建的 session 应使用该 workspace_root"""
+    from pathlib import Path
+
+    ws = Path(tmp_path) / "workspace"
+    ws.mkdir()
+    app = create_app(ScriptedLLM([LLMResponse(content="ok")]), workspace_root=ws)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/new") as w:
+            created = w.receive_json()
+            session = app.state.session_manager.get_session(created["session_id"])
+            assert session is not None
+            # Agent's workspace_policy should have the correct root
+            policy = session.agent.tool_registry.workspace_policy
+            assert policy is not None
+            assert policy.workspace_root == ws.resolve()

--- a/web/server.py
+++ b/web/server.py
@@ -37,6 +37,7 @@ def create_app(
     mode: str | None = None,
     config: AsterwyndConfig | None = None,
     resume: str | None = None,
+    workspace_root: Path | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application."""
     config = config or AsterwyndConfig()
@@ -47,7 +48,9 @@ def create_app(
         debug_enabled=debug_enabled(),
         mode=resolved_mode,
         config=config,
+        workspace_root=workspace_root,
     )
+    app.state.session_manager = session_manager
 
     # Mount static files at /static
     if STATIC_DIR.exists():

--- a/web/session.py
+++ b/web/session.py
@@ -2,6 +2,7 @@
 """Session manager: one AgentLoop + message history per browser session."""
 import asyncio
 import logging
+from pathlib import Path
 from typing import Optional
 
 from agent.approval import (
@@ -177,10 +178,12 @@ class SessionManager:
         debug_enabled: bool = False,
         mode: str | None = None,
         config: AsterwyndConfig | None = None,
+        workspace_root: Path | None = None,
     ):
         self._sessions: dict[str, AgentSession] = {}
         self.debug_enabled = debug_enabled
         self.config = config or AsterwyndConfig()
+        self.workspace_root = workspace_root
         resolved_mode = mode or self.config.agent.default_mode.value
         self.initial_mode = parse_agent_mode(resolved_mode)
 
@@ -204,6 +207,7 @@ class SessionManager:
         question_handler = WebQuestionHandler(session_id)
         run_config = AgentRunConfig(mode=self.initial_mode)
         workspace_policy = WorkspacePolicy(
+            workspace_root=self.workspace_root,
             command_denylist=self.config.tools.command_denylist,
         )
         registry = build_default_tool_registry(


### PR DESCRIPTION
给 CLI 和 Web 增加 `--workspace` 参数指定主工作目录。Session 中可通过 `/session-workspace add/remove/list` 动态增减附加 workspace。

## 模型

```
--workspace /home/project-a   →  主 workspace_root
                                    ├── ASTER.md, .asterwynd/, config, sessions
                                    └── 所有工具默认边界

/session-workspace add /tmp/data → 附加 workspace，只扩展读写边界
```

## 核心改动

| 文件 | 变更 |
|------|------|
| `agent/workspace_policy.py` | additional_roots, add_root/remove_root/list_roots, is_within_workspace, relative_path, shell substitution denylist |
| `agent/main.py` | --workspace 参数 + 全线传递 (run/web/session/callback) |
| `agent/commands/registry.py` | /session-workspace slash command |
| `agent/loop.py` | BuildContext.cwd 使用 workspace_policy.workspace_root |
| `agent/tools/registry.py` + `factory.py` | ToolRegistry.workspace_policy 挂载 |
| `web/server.py` + `web/session.py` | workspace_root 传递链 |

## 测试

| 文件 | 新增 | 合计 |
|------|------|------|
| `tests/agent/test_workspace_policy.py` | 21 | 69 |
| `tests/agent/commands/test_session_workspace.py` | 12 | 12 |
| `tests/agent/tools/test_registry.py` | 3 | 18 |
| `tests/agent/test_loop.py` | 2 | 62 |
| `tests/test_cli.py` | 7 | 42 |
| `tests/web_tests/test_server.py` | 3 | 30 |

全量 **237 passed, 0 failed**。

## 安全防护

- realpath 解析 + 系统敏感目录拒绝 (/etc, /proc, /sys, /dev, /root, /boot)
- 祖先/子目录检查
- shell substitution denylist ($() / 反引号)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>