### PR TITLE
docs: README 增加 OrcaRouter 作为 OpenAI 兼容网关示例（含致谢链接）

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ uv sync --extra dev              # 运行时 + 开发/测试依赖
 # 配置 API Key 和模型
 cp .env.example .env
 # 编辑 .env，填入 OPENAI_API_KEY 或 ANTHROPIC_API_KEY
-# 可选：改 OPENAI_BASE_URL 指向其他 OpenAI 兼容 API（如 DeepSeek）
+# 可选：改 OPENAI_BASE_URL 指向任意 OpenAI 兼容 API（如 DeepSeek、OrcaRouter 等）
 # 可选：设置 ASTERWYND_PROVIDER（openai / anthropic）和 ASTERWYND_MODEL 作为默认值
 
 # 运行 CLI（OpenAI，默认；用 .env 配置的 ASTERWYND_MODEL）
@@ -468,3 +468,7 @@ Python 3.11+ / asyncio / FastAPI / httpx / typer / tiktoken（可选）
 - `docs/coding-agent-roadmap.md` — 编码 Agent 路线图
 - `docs/benchmark-plan.md` — benchmark 设计（本地 runner、SWE-bench Docker harness、Claw-SWE-Bench 对比入口）
 - `CLAW-SWE-BENCH.md` — Claw-SWE-Bench 集成和运行指南
+
+## 致谢
+
+- [OrcaRouter](https://www.orcarouter.ai/ref/ref_4c1cf5a5bb71174f474d) — 多模型网关（含 DeepSeek、千问 等免费模型）。把 `OPENAI_BASE_URL` 设为 `https://api.orcarouter.ai/v1` 即可通过 asterwynd 使用。

--- a/README_EN.md
+++ b/README_EN.md
@@ -44,7 +44,7 @@ uv sync --extra dev              # runtime + development/test dependencies
 # Configure API key and model
 cp .env.example .env
 # Edit .env and set OPENAI_API_KEY or ANTHROPIC_API_KEY
-# Optional: set OPENAI_BASE_URL for another OpenAI-compatible API, such as DeepSeek
+# Optional: set OPENAI_BASE_URL for any OpenAI-compatible API, such as DeepSeek, OrcaRouter, etc.
 # Optional: set ASTERWYND_PROVIDER (openai / anthropic) and ASTERWYND_MODEL as defaults
 
 # Run CLI (OpenAI by default, using ASTERWYND_MODEL from .env)
@@ -469,5 +469,9 @@ Python 3.11+ / asyncio / FastAPI / httpx / typer / tiktoken (optional)
 - `docs/coding-agent-roadmap.md`: Coding Agent roadmap
 - `docs/benchmark-plan.md`: benchmark design for the local runner, SWE-bench Docker harness, and Claw-SWE-Bench comparison path
 - `CLAW-SWE-BENCH.md`: Claw-SWE-Bench integration and running guide
+
+## Acknowledgements
+
+- [OrcaRouter](https://www.orcarouter.ai/ref/ref_4c1cf5a5bb71174f474d) — a multi-model gateway with free models such as DeepSeek and Qwen. Set `OPENAI_BASE_URL` to `https://api.orcarouter.ai/v1` to use it with asterwynd.
 
 > Chinese source: [README.md](./README.md)


### PR DESCRIPTION
## 背景

OrcaRouter 的 OSS 计划（Built With / Open Source Program）向 asterwynd 发出接入邀约。与 Maria 邮件确认：asterwynd 作为 OpenAI 兼容 CLI（`OPENAI_BASE_URL` 可覆盖），用户经专属 Referral Link 注册后以 BYOK 方式填 key 即可使用并归因，**无需改任何代码 / OAuth / PKCE**。因此本 PR 只做文档层面的平级入口。

## 改动

- `README.md` 快速开始：能力声明由"其他 OpenAI 兼容 API（如 DeepSeek）"扩为"任意 OpenAI 兼容 API（如 DeepSeek、OrcaRouter 等）"
- `README.md` 文末新增「致谢」小节，放 OrcaRouter 注册链接（带 ref 归因）+ base URL 配置说明
- `README_EN.md` 同步翻译（仓库规则：README 修改必须同一变更内同步英文）

## 口径

OrcaRouter 只作为 OpenAI 兼容网关的众多选项之一平级列出，不构成对第三方服务的背书或导流。放文末致谢而非快速开始首屏，保持上手路径纯净。无代码、无测试变更，纯文档。

## 验证

- [x] 中英对应行已核对一致（改动 1：README.md:47 ↔ README_EN.md:47；改动 2：README.md:472-475 ↔ README_EN.md:474-476）
- [x] diff 仅 2 个文件、10 insertions / 2 deletions