### PR TITLE
chore: .env.example 补充 HF_ENDPOINT 可选配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ ASTERWYND_MODEL=
 # 可选：自定义 API Base URL
 OPENAI_BASE_URL=https://api.openai.com/v1
 ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+# 可选：HuggingFace 镜像（国内网络访问 huggingface.co 时用 hf-mirror）
+HF_ENDPOINT=https://hf-mirror.com


### PR DESCRIPTION
## 背景

本机（国内网络）跑 SWE-bench Verified 的 Docker harness 时，`swebench.harness.run_evaluation` 需要从 huggingface.co 下载数据集，直接访问会 600s 超时挂起。设置 `HF_ENDPOINT=https://hf-mirror.com` 后镜像可达，端到端验证 requests-1142 resolved=true。

## 改动

- `.env.example` 末尾补充 `HF_ENDPOINT=https://hf-mirror.com` 可选配置（国内网络跑 swebench 用 hf-mirror）
- 本地 `.env` 已同步加该变量（不提交）

## 验证

- 端到端单任务跑通：agent 解决 requests-1142（resolved=true，FAIL_TO_PASS + PASS_TO_PASS 全过）